### PR TITLE
Parse shader bindings from JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ source = "git+https://github.com/gfx-rs/gfx.git?rev=7d4b4f1#7d4b4f16de9841e403f0
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -7,10 +7,10 @@ repository = "https://github.com/servo/webrender"
 build = "build.rs"
 
 [features]
-default = ["freetype-lib", "vulkan"]
+default = ["freetype-lib", "vulkan", "gfx-hal/serde", "serde_json"]
 freetype-lib = ["freetype/servo-freetype-sys"]
 profiler = ["thread_profiler/thread_profiler"]
-debugger = ["ws", "serde_json", "serde", "serde_derive", "image", "base64"]
+debugger = ["ws", "serde", "serde_derive", "image", "base64"]
 vulkan = ["gfx-backend-vulkan"]
 
 [dependencies]
@@ -30,7 +30,7 @@ bitflags = "1.0"
 thread_profiler = "0.1.1"
 plane-split = "0.7"
 smallvec = "0.6"
-gfx-hal = { git = "https://github.com/gfx-rs/gfx.git", rev= "7d4b4f1" }
+gfx-hal = { git = "https://github.com/gfx-rs/gfx.git", rev= "7d4b4f1" , feature = "serde"}
 winit = "0.9"
 ws = { optional = true, version = "0.7.3" }
 serde_json = { optional = true, version = "1.0" }

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -59,3 +59,4 @@ core-text = { version = "8.0", default-features = false }
 
 [build-dependencies]
 serde_json =  "1.0"
+gfx-hal = { git = "https://github.com/gfx-rs/gfx.git", rev= "7d4b4f1" , feature = "serde"}

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -4,7 +4,9 @@
 
 #[macro_use]
 extern crate serde_json;
+extern crate gfx_hal;
 
+use gfx_hal::pso::ShaderStageFlags;
 use serde_json::value::Value as JsonValue;
 use std::cmp::max;
 use std::env;
@@ -506,7 +508,7 @@ fn replace_sampler_definition_with_texture_and_sampler(
                         "binding": binding,
                         "ty": "SampledImage",
                         "count": 1,
-                        "stage_flags": "All",
+                        "stage_flags": ShaderStageFlags::ALL,
                     }));
         }
         new_data.push_str(&layout_str);
@@ -529,7 +531,7 @@ fn replace_sampler_definition_with_texture_and_sampler(
                         "binding": binding,
                         "ty": "Sampler",
                         "count": 1,
-                        "stage_flags": "All",
+                        "stage_flags": ShaderStageFlags::ALL,
                     }));
         }
         new_data.push_str(&layout_str);
@@ -555,7 +557,7 @@ fn add_locals_to_descriptor_set_layout(descriptor_set_layouts: &mut Vec<JsonValu
         "binding": 0,
         "ty": "UniformBuffer",
         "count": 1,
-        "stage_flags": "Vertex",
+        "stage_flags": ShaderStageFlags::VERTEX,
     }));
 }
 

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -435,9 +435,7 @@ fn process_glsl_for_spirv(file_path: &Path, file_name: &str) -> Option<JsonValue
         pipeline_requirmenets.insert("descriptorPool", descriptor_pool);
         pipeline_requirmenets.insert("descriptorSetLayouts", json!(descriptor_set_layouts));
         pipeline_requirmenets.insert("vertexBufferDescriptors", json!(vertex_buffer_descriptors));
-        return Some(json!({
-            file_name.trim_right_matches(".vert"): pipeline_requirmenets
-        }));
+        return Some(json!(pipeline_requirmenets));
     }
     None
 }
@@ -722,11 +720,11 @@ fn create_vertex_buffer_descriptors_json(file_name: &str) -> Vec<JsonValue> {
 }
 
 fn compile_glsl_to_spirv(file_name_vector: Vec<String>, out_dir: &str) -> JsonValue {
-    let mut requirements = Vec::new();
+    let mut requirements = serde_json::Map::new();
     for mut file_name in file_name_vector {
         let file_path = Path::new(&out_dir).join(&file_name);
         if let Some(req) = process_glsl_for_spirv(&file_path, &file_name) {
-            requirements.push(req);
+            requirements.insert(file_name.trim_right_matches(".vert").to_owned(), req);
         }
         file_name.push_str(".spv");
         let spirv_file_path = Path::new(&out_dir).join(&file_name);

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -79,6 +79,7 @@ mod glyph_rasterizer;
 mod gpu_cache;
 mod gpu_types;
 mod internal_types;
+mod parser;
 mod picture;
 mod prim_store;
 mod print_tree;
@@ -148,7 +149,6 @@ extern crate rayon;
 #[cfg(feature = "debugger")]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(feature = "debugger")]
 extern crate serde_json;
 extern crate smallvec;
 extern crate time;

--- a/webrender/src/parser.rs
+++ b/webrender/src/parser.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use device::{PrimitiveInstance, Vertex};
+use hal::pso::{AttributeDesc, DescriptorRangeDesc, DescriptorSetLayoutBinding, VertexBufferDesc};
+use serde_json::{self, Error, Value};
+use std::collections::HashMap;
+use std::io::prelude::*;
+use std::fs::File;
+use std::mem;
+
+const ATTRIBUTE_DESCRIPTORS: &'static str = "attributeDescriptors";
+const DESCRIPTORS: &'static str = "descriptors";
+const DESCRIPTOR_POOL: &'static str = "descriptorPool";
+const DESCRIPTOR_SET_LAYOUTS: &'static str = "descriptorSetLayouts";
+const BINDING: &'static str = "binding";
+const NAME: &'static str = "name";
+const RATE: &'static str = "rate";
+const SETS: &'static str = "sets";
+const STRIDE: &'static str = "stride";
+const VERTEX_BUFFER_DESCRIPTORS: &'static str = "vertexBufferDescriptors";
+
+pub fn read_json() -> Value {
+    //include_bytes!(concat!(env!("OUT_DIR"), "/pipelines.json"))
+    let mut file =
+        File::open(concat!(env!("OUT_DIR"), "/pipelines.json")).expect("Unable to open the file");
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("Unable to read the file");
+    serde_json::from_str(&content).expect("Unable to create json")
+}
+
+pub fn create_attribute_descriptors(json: &Value, shader_name: &str) -> Vec<AttributeDesc> {
+    let descriptors = &json[shader_name][ATTRIBUTE_DESCRIPTORS]
+        .as_array()
+        .expect("Unable to create array");
+    descriptors
+        .iter()
+        .map(|d| {
+            serde_json::from_str(&d.to_string()).expect("Unable to create attribute descriptor")
+        })
+        .collect::<Vec<AttributeDesc>>()
+}
+
+pub fn create_range_descriptors_and_set_count(
+    json: &Value,
+    shader_name: &str,
+) -> (Vec<DescriptorRangeDesc>, usize) {
+    let range_descriptors = &json[shader_name][DESCRIPTOR_POOL][DESCRIPTORS]
+        .as_array()
+        .expect("Unable to create array");
+    let range_descs = range_descriptors
+        .iter()
+        .map(|d| serde_json::from_str(&d.to_string()).expect("Unable to create range descriptor"))
+        .collect::<Vec<DescriptorRangeDesc>>();
+    let set_count = *&json[shader_name][DESCRIPTOR_POOL][SETS]
+        .as_i64()
+        .expect("Unable to get number of sets") as usize;
+    (range_descs, set_count)
+}
+
+pub fn create_descriptor_set_layout_bindings(
+    json: &Value,
+    shader_name: &str,
+) -> (Vec<DescriptorSetLayoutBinding>, HashMap<String, usize>) {
+    let descriptor_set_layouts = &json[shader_name][DESCRIPTOR_SET_LAYOUTS]
+        .as_array()
+        .expect("Unable to create array");
+    let mut descriptors = HashMap::new();
+    let ds_layouts = descriptor_set_layouts
+        .iter()
+        .map(|d| {
+            descriptors.insert(d[NAME].as_str().unwrap().to_owned(), d[BINDING].as_i64().unwrap() as usize);
+            serde_json::from_str(&d.to_string())
+                .expect("Unable to create descriptor set layout bindings")
+        })
+        .collect::<Vec<DescriptorSetLayoutBinding>>();
+    (ds_layouts, descriptors)
+}
+
+pub fn create_vertex_buffer_descriptors(json: &Value, shader_name: &str) -> Vec<VertexBufferDesc> {
+    let vertex_buffer_descriptors_json = &json[shader_name][VERTEX_BUFFER_DESCRIPTORS]
+        .as_array()
+        .expect("Unable to create array");
+    let mut vertex_buffer_descriptors = Vec::with_capacity(vertex_buffer_descriptors_json.len());
+    for desc_json in vertex_buffer_descriptors_json.iter() {
+        let stride = match desc_json[STRIDE].as_str().unwrap() {
+            "Vertex" => mem::size_of::<Vertex>() as u32,
+            "PrimitiveInstance" => mem::size_of::<PrimitiveInstance>() as u32,
+            //TODO
+            _ => 0,
+        };
+        let desc = VertexBufferDesc {
+            stride: stride,
+            rate: desc_json[RATE].as_u64().unwrap() as u8,
+        };
+        vertex_buffer_descriptors.push(desc);
+    }
+    vertex_buffer_descriptors
+}


### PR DESCRIPTION
1. We parse the build time created json file into Vecs and a Map. We can use these collections to create pipelines with less code, also we can determine the binding indices for texture updates from these.

2. Added the `gfx_hal::pso::ShaderStageFlags` enum to the build script, because it has special serialization rules.