### PR TITLE
Fix reset

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -584,7 +584,7 @@ impl<B: hal::Backend> InstanceBuffer<B> {
     }
 
     pub fn reset(&mut self) {
-        self.size = 1;
+        self.size = 0;
         self.offset = 0;
     }
 
@@ -2276,6 +2276,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             self.current_frame_id = (self.current_frame_id + 1) % self.framebuffers.len();
         }
         self.upload_queue.clear();
+        self.command_pool.reset();
         self.device.destroy_fence(frame_fence);
         self.device.destroy_semaphore(frame_semaphore);
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2935,8 +2935,22 @@ impl Renderer {
     }
 
     fn flush(&mut self) {
+        self.brush_line.instance_buffer.reset();
+        self.brush_mask_corner.instance_buffer.reset();
+        self.brush_mask_rounded_rect.instance_buffer.reset();
+        self.brush_picture_rgba8.instance_buffer.reset();
+        self.brush_picture_rgba8_alpha_mask.instance_buffer.reset();
+        self.brush_picture_a8.instance_buffer.reset();
+        self.brush_solid.instance_buffer.reset();
         self.ps_border_corner.instance_buffer.reset();
         self.ps_border_edge.instance_buffer.reset();
+        self.ps_gradient.instance_buffer.reset();
+        self.ps_angle_gradient.instance_buffer.reset();
+        self.ps_radial_gradient.instance_buffer.reset();
+        self.ps_blend.instance_buffer.reset();
+        self.ps_hw_composite.instance_buffer.reset();
+        self.ps_split_composite.instance_buffer.reset();
+        self.ps_composite.instance_buffer.reset();
     }
 
     pub fn layers_are_bouncing_back(&self) -> bool {


### PR DESCRIPTION
The size value was wrongly set to 1, which caused some unwanted artifacts in the drawings.
Also call the reset function on the other shaders.