### PR TITLE
Setup continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,17 @@
+sudo: false
 dist: trusty
 language: rust
-rust:
-  - 1.22.1
-  - nightly
-matrix:
-  fast_finish: true
-  allow_failures:
-  - rust: nightly
-os:
-  - linux
-#  - osx
+cache:
+  cargo: true
 
-# Travis is slow and often backlogged so we only run it on the "auto" branch
-# which is what bors uses to test the merge commit when merging a PR. Individual
-# PRs can catch errors by checking the taskcluster result instead.
+matrix:
+  include:
+    - os: linux
+      rust: stable
+
 branches:
   only:
-    - auto
-notifications:
-  webhooks: http://build.servo.org:54856/travis
+    - master
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main'
-        keyurl: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
-      - sourceline: 'ppa:jonathonf/python-2.7'
-    packages:
-      - libgl1-mesa-dev
-      - llvm-3.9-dev
-      - libedit-dev
-      - python
-env:
-  - BUILD_KIND=DEBUG RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
-  - BUILD_KIND=RELEASE RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LLVM_CONFIG=/usr/lib/llvm-3.9/bin/llvm-config; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zlib; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"; fi
-  - virtualenv ../venv
-  - source ../venv/bin/activate
-  - python --version
-  - pip install mako servo-tidy
 script:
-  - servo-tidy
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_api && cargo test --verbose --features "ipc"); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features profiler,capture); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cargo test --all --verbose); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python script/headless.py reftest); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && cargo build --release); fi
-  - if [ $TRAVIS_RUST_VERSION == "nightly" ]; then (cd webrender && cargo bench --verbose); fi
+  - cargo build --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=d78bd11)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=d78bd11)",
  "gleam 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glsl-to-spirv 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,14 @@
 environment:
-  PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Rust\bin'
+  PATH: '%PATH%;C:\msys64\mingw64\bin;C:\msys64\usr\bin;%USERPROFILE%\.cargo\bin'
   RUST_BACKTRACE: 1
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.22.1-x86_64-pc-windows-gnu.msi"
-  - msiexec /passive /i "rust-1.22.1-x86_64-pc-windows-gnu.msi" ADDLOCAL=Rustc,Cargo,Std INSTALLDIR=C:\Rust
-  - bash -lc "pacman -S --noconfirm mingw-w64-x86_64-cmake"
-  - rustc -V
-  - cargo -V
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init -yv --default-toolchain stable
+  - rustc -vV
+  - cargo -vV
 
 build: false
 
 test_script:
-  - cd webrender_api
-  - cargo test --verbose
-  - cd ../webrender
-  - cargo test --verbose
-  - cd ../wrench
-  - cargo test --verbose
+  - cargo build --verbose

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -60,6 +60,7 @@ core-graphics = "0.12.3"
 core-text = { version = "8.0", default-features = false }
 
 [build-dependencies]
+glsl-to-spirv = { version = "0.1" }
 gfx-hal = { git = "https://github.com/gfx-rs/gfx.git", rev= "d78bd11" , feature = "serde"}
 ron = "0.1.7"
 serde = { version = "1", features = ["serde_derive"] }

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -608,7 +608,11 @@ fn compile_glsl_to_spirv(file_name_vector: Vec<String>, out_dir: &str) ->  HashM
         file_name.push_str(".spv");
         let spirv_file_path = Path::new(&out_dir).join(&file_name);
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        let mut glslang_cmd = Command::new(Path::new("./tools/glslangValidator"));
+        let mut glslang_validator = String::from_utf8(Command::new("find").arg("../").arg("-name").arg("glslang_validator").output().unwrap().stdout).unwrap();
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        glslang_validator.pop(); // remove \n
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        let mut glslang_cmd = Command::new(Path::new(&glslang_validator));
         #[cfg(target_os = "windows")]
         let mut glslang_cmd = Command::new(Path::new("./tools/glslangValidator.exe"));
         glslang_cmd


### PR DESCRIPTION
Issue: #79 
This is only builds the code. After we support e.g. OpenGL headless we can enable reftesting.

Note: We can't use `./tools/glslangValidator` on travis, because there are dependency incompatibility there. But fortunately we can build it as well and use that version.