### PR TITLE
Add dummy aData for cache clip shaders

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -508,24 +508,6 @@ fn add_attribute_descriptors(
             );
             *vertex_offset += offset;
         }
-        // All shader files contain aData0 and aData1 variables.
-        // We must remove them from the attribute descriptors of blur and clip shaders,
-        // because they are not used in these and we don't want them when calculating offsets.
-        "aData0" | "aData1" => {
-            if !(file_name.starts_with("cs_blur") || file_name.starts_with("cs_clip")) {
-                attribute_descriptors.push(
-                    AttributeDesc {
-                        location: *in_location,
-                        binding: 1,
-                        element: Element {
-                            format: format,
-                            offset: *instance_offset,
-                        }
-                    }
-                );
-                *instance_offset += offset;
-            }
-        }
         _ => {
             attribute_descriptors.push(
                 AttributeDesc {
@@ -569,14 +551,14 @@ fn create_vertex_buffer_descriptors(file_name: &str) -> Vec<VertexBufferDesc> {
     if file_name.starts_with("cs_blur") {
         descriptors.push(
             VertexBufferDesc {
-                stride: 12, // size of Bluerinstance 3 * 4
+                stride: 12 + 32, // size of Bluerinstance 3 * 4 + PrimitiveInstance 8 * 4
                 rate: 1,
             }
         );
     } else if file_name.starts_with("cs_clip") {
         descriptors.push(
             VertexBufferDesc {
-                stride: 28, // size of ClipMaskInstance 3 * 4 + 4 * 4
+                stride: 28 + 32, // size of ClipMaskInstance 3 * 4 + 4 * 4 + PrimitiveInstance 8 * 4
                 rate: 1,
             }
         );

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -86,6 +86,8 @@ pub struct PrimitiveInstance {
 #[derive(Debug, Clone, Copy)]
 #[allow(non_snake_case)]
 pub struct ClipMaskInstance {
+    pub aData0: [i32; 4],
+    pub aData1: [i32; 4],
     pub aClipRenderTaskAddress: i32,
     pub aScrollNodeId: i32,
     pub aClipSegment: i32,
@@ -95,6 +97,8 @@ pub struct ClipMaskInstance {
 #[derive(Debug, Clone, Copy)]
 #[allow(non_snake_case)]
 pub struct BlurInstance {
+    pub aData0: [i32; 4],
+    pub aData1: [i32; 4],
     pub aBlurRenderTaskAddress: i32,
     pub aBlurSourceTaskAddress: i32,
     pub aBlurDirection: i32,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -315,6 +315,8 @@ impl From<GlyphFormat> for TextShaderMode {
 impl<'a> From<&'a gpu_types::BlurInstance> for BlurInstance {
     fn from(instance: &'a gpu_types::BlurInstance) -> BlurInstance {
         BlurInstance {
+            aData0: [0, 0, 0, 0],
+            aData1: [0, 0, 0, 0],
             aBlurRenderTaskAddress: instance.task_address.0 as i32,
             aBlurSourceTaskAddress: instance.src_task_address.0 as i32,
             aBlurDirection: instance.blur_direction as i32,
@@ -325,6 +327,8 @@ impl<'a> From<&'a gpu_types::BlurInstance> for BlurInstance {
 impl<'a> From<&'a gpu_types::ClipMaskInstance> for ClipMaskInstance {
     fn from(instance: &'a gpu_types::ClipMaskInstance) -> ClipMaskInstance {
         ClipMaskInstance {
+            aData0: [0, 0, 0, 0],
+            aData1: [0, 0, 0, 0],
             aClipRenderTaskAddress: instance.render_task_address.0 as i32,
             aScrollNodeId: instance.scroll_node_data_index.0 as i32,
             aClipSegment: instance.segment,


### PR DESCRIPTION
This is just a quick workaround. The proper solution should be removing the aData from the shaders, but we don't want to change the shader code by hand.

Fixes: https://github.com/szeged/webrender/issues/95