### PR TITLE
Add dx12 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gfx-backend-empty"
+version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx.git#d09e24dc951a19b0561d384c15d88275afb29851"
+dependencies = [
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
+]
+
+[[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#211613c95f678aa7573835313a15facc8adac60d"
@@ -1610,6 +1618,7 @@ dependencies = [
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-loader 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
+ "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gleam 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1763,6 +1772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
+"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dlib"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +480,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gfx-backend-dx12"
+version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx.git#211613c95f678aa7573835313a15facc8adac60d"
+replace = "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)"
+
+[[package]]
+name = "gfx-backend-dx12"
+version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5#b75b8f5e5db8983eb55363a41c58bd55312f9c9b"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -650,6 +682,14 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1134,9 +1174,26 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "spirv_cross"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"
@@ -1404,6 +1461,7 @@ dependencies = [
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gleam 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1528,6 +1586,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wrench"
 version = "0.3.0"
 dependencies = [
@@ -1543,6 +1609,7 @@ dependencies = [
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-loader 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
  "gleam 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1674,6 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
+"checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum dwrote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b26e30aaa6bf31ec830db15fec14ed04f0f2ecfcc486ecfce88c55d3389b237f"
@@ -1693,6 +1761,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
+"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
+"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
@@ -1710,6 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9f47468e9a76a6452271efadc88fe865a82be91fe75e6c0c57b87ccea59d4"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipc-channel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a5cddad3b796bb3762d43cd8beaad6650860225b1b370ef5f8d3503f4dc0462"
+"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum jpeg-decoder 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfe27a6c0dabd772d0f9b9f8701c4ca12c4d1eebcadf2be1f6f70396f6a1434"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1773,7 +1844,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44db0ecb22921ef790d17ae13a3f6d15784183ff5f2a01aa32098c7498d2b4b9"
+"checksum spirv_cross 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "65c3c83789d789bdbf1d6c2c211b9aa27ff19ca939d293809fbdb360df49b00b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
@@ -1812,6 +1885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
 "checksum winit 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "491e1305250e728fd9b8ef86ecef4e17a3293e87e51c7bc31e7a3913ec957d37"
 "checksum winit 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a29847ed6928d6cbabe6b2d5b11dd0ce63380af53a8dcd41775d27d104d285"
+"checksum wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a31e8a268d6941ffb7f8d7989fc93e4692bd3e75a27d400a72b4be1dadb213"
 "checksum ws 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ccf752fee5350ca505fdb0b34d503b17d1528bd867561b7aa91d6ea750d5e972"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a86db9d61a3697ded72bb068b4b641a752aaba77a6ce569827bc7e97dc4c5b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ panic = "abort"
 [replace]
 "https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5"}
 "https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0"= { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0"= { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5" }

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -7,13 +7,14 @@ repository = "https://github.com/servo/webrender"
 build = "build.rs"
 
 [features]
-default = ["freetype-lib", "vulkan", "gfx-hal/serde"]
+default = ["freetype-lib", "gfx-hal/serde"]
 freetype-lib = ["freetype/servo-freetype-sys"]
 profiler = ["thread_profiler/thread_profiler"]
 debugger = ["ws", "serde_json", "image", "base64"]
 capture = ["webrender_api/serialize"]
 replay = ["webrender_api/deserialize"]
-vulkan = []
+vulkan = ["gfx-backend-vulkan"]
+dx12 = ["gfx-backend-dx12"]
 
 [dependencies]
 app_units = "0.6"
@@ -42,13 +43,14 @@ ron = { version = "0.1.7" }
 winit = "0.11"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx.git" }
 rand = "0.4"
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
 
 [dev-dependencies]
 mozangle = "0.1"
 env_logger = "0.5"
 rand = "0.3"                # for the benchmarks
 glutin = "0.12"             # for the example apps
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git" }
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
 freetype = { version = "0.3", default-features = false }

--- a/webrender/examples/common/boilerplate_hal.rs
+++ b/webrender/examples/common/boilerplate_hal.rs
@@ -7,6 +7,8 @@ extern crate euclid;
 extern crate gfx_hal;
 #[cfg(feature = "vulkan")]
 extern crate gfx_backend_vulkan as back;
+#[cfg(feature = "dx12")]
+extern crate gfx_backend_dx12 as back;
 
 use std::env;
 use std::path::PathBuf;

--- a/webrender/examples/common/boilerplate_hal.rs
+++ b/webrender/examples/common/boilerplate_hal.rs
@@ -85,6 +85,7 @@ pub trait Example {
     }
 }
 
+#[cfg(any(feature = "vulkan", feature = "dx12"))]
 pub fn main_wrapper<E: Example>(
     example: &mut E,
     options: Option<webrender::RendererOptions>,
@@ -215,4 +216,12 @@ pub fn main_wrapper<E: Example>(
     });
 
     renderer.deinit();
+}
+
+#[cfg(not(any(feature = "vulkan", feature = "dx12")))]
+pub fn main_wrapper<E: Example>(
+    _example: &mut E,
+    _options: Option<webrender::RendererOptions>,
+) {
+    println!("You need to enable native API features (vulkan/dx12) in order to test webrender");
 }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1094,11 +1094,9 @@ impl<B: hal::Backend> Program<B> {
         shader_kind: &ShaderKind,
         render_pass: &RenderPass<B>,
     ) -> Program<B> {
-        #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
         let vs_module = device
             .create_shader_module(get_shader_source(shader_name, ".vert.spv").as_slice())
             .unwrap();
-        #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
         let fs_module = device
             .create_shader_module(get_shader_source(shader_name, ".frag.spv").as_slice())
             .unwrap();

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -32,6 +32,7 @@ winit = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 gfx-hal = { git = "https://github.com/gfx-rs/gfx.git" }
 gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.13"
@@ -42,6 +43,7 @@ default = ["vulkan"]
 headless = [ "osmesa-sys", "osmesa-src" ]
 logging = [ "env_logger" ]
 vulkan = [ "gfx-backend-vulkan" ]
+dx12 = [ "gfx-backend-dx12" ]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.4.1"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -33,13 +33,14 @@ serde = {version = "1.0", features = ["derive"] }
 gfx-hal = { git = "https://github.com/gfx-rs/gfx.git" }
 gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
 gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
+gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx.git" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.13"
 core-foundation = "0.5"
 
 [features]
-default = ["vulkan"]
+default = []
 headless = [ "osmesa-sys", "osmesa-src" ]
 logging = [ "env_logger" ]
 vulkan = [ "gfx-backend-vulkan" ]

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -22,6 +22,8 @@ extern crate euclid;
 extern crate font_loader;
 #[cfg(feature = "vulkan")]
 extern crate gfx_backend_vulkan as back;
+#[cfg(feature = "dx12")]
+extern crate gfx_backend_dx12 as back;
 extern crate gfx_hal as hal;
 extern crate image;
 #[macro_use]

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -24,6 +24,8 @@ extern crate font_loader;
 extern crate gfx_backend_vulkan as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
+#[cfg(not(any(feature = "vulkan", feature = "dx12")))]
+extern crate gfx_backend_empty as back;
 extern crate gfx_hal as hal;
 extern crate image;
 #[macro_use]
@@ -283,6 +285,7 @@ fn create_notifier() -> (Box<RenderNotifier>, Receiver<()>) {
     (Box::new(Notifier { tx: tx }), rx)
 }
 
+#[cfg(any(feature = "vulkan", feature = "dx12"))]
 fn main() {
     #[cfg(feature = "logging")]
     env_logger::init();
@@ -584,4 +587,9 @@ fn main() {
     }
 
     wrench.renderer.deinit();
+}
+
+#[cfg(not(any(feature = "vulkan", feature = "dx12")))]
+fn main() {
+    println!("You need to enable native API features (vulkan/dx12) in order to test webrender");
 }


### PR DESCRIPTION
Add dx12 as an optional backend.
NOTE: Until https://github.com/gfx-rs/gfx/issues/1905 is not solved dx12 will crash.