### PR TITLE
Use copy buffer alignment again

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -13,7 +13,8 @@ use rand::{self, Rng};
 use serde;
 use std::collections::HashMap;
 use smallvec::SmallVec;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::cmp;
 use std::fs::File;
 use std::io::Read;
 use std::marker::PhantomData;
@@ -504,21 +505,21 @@ const LESS_EQUAL_WRITE: DepthTest = DepthTest::On {
 };
 
 pub struct ImageBuffer<B: hal::Backend> {
-    pub buffer: Buffer<B>,
+    pub buffer: CopyBuffer<B>,
     pub offset: u64,
 }
 
 impl<B: hal::Backend> ImageBuffer<B> {
-    fn new(buffer: Buffer<B>) -> ImageBuffer<B> {
+    fn new(buffer: CopyBuffer<B>) -> ImageBuffer<B> {
         ImageBuffer {
             buffer,
             offset: 0,
         }
     }
 
-    pub fn update(&mut self, device: &B::Device, data: &[u8]) {
+    pub fn update(&mut self, device: &B::Device, data: &[u8], offset_alignment: usize) -> usize {
         self.buffer
-            .update(device, self.offset, data.len() as u64, data);
+            .update(device, self.offset, data.len() as u64, data, offset_alignment)
     }
 
     pub fn reset(&mut self) {
@@ -641,19 +642,22 @@ impl<B: hal::Backend> Image<B> {
         image_width: u32,
         image_height: u32,
         image_depth: i32,
+        pitch_alignment: usize,
     ) -> Self {
-        let (data_stride, format) = match image_format {
+        let (bytes_per_pixel, format) = match image_format {
             ImageFormat::R8 => (1, hal::format::Format::R8Unorm),
             ImageFormat::RG8 => (2, hal::format::Format::Rg8Unorm),
             ImageFormat::BGRA8 => (4, hal::format::Format::Bgra8Unorm),
             _ => unimplemented!("TODO image format missing"),
         };
-        let upload_buffer = Buffer::create(
+        let upload_buffer = CopyBuffer::create(
             device,
             memory_types,
             hal::buffer::Usage::TRANSFER_SRC,
-            data_stride,
-            (image_width * image_height) as usize,
+            1, // Data stride is 1, because we receive image data as [u8].
+            (image_width * bytes_per_pixel) as usize,
+            image_height as usize,
+            pitch_alignment,
         );
 
         let kind = hal::image::Kind::D2(
@@ -691,12 +695,13 @@ impl<B: hal::Backend> Image<B> {
         rect: DeviceUintRect,
         layer_index: i32,
         image_data: &[u8],
+        offset_alignment: usize,
     ) -> hal::command::Submit<B, hal::Graphics, hal::command::MultiShot, hal::command::Primary>
     {
         //let (image_width, image_height, _, _) = self.kind.dimensions();
         let pos = rect.origin;
         let size = rect.size;
-        self.upload_buffer.update(device, image_data);
+        let offset = self.upload_buffer.update(device, image_data, offset_alignment);
         let mut cmd_buffer = cmd_pool.acquire_command_buffer(false);
 
         if let Some(barrier) = self.core.transit(
@@ -710,6 +715,11 @@ impl<B: hal::Backend> Image<B> {
             );
         }
 
+        let buffer_width = if self.kind.extent().width == size.width {
+            self.upload_buffer.buffer.row_pitch() as u32 / self.format.bytes_per_pixel()
+        } else {
+            size.width
+        };
         cmd_buffer.copy_buffer_to_image(
             &self.upload_buffer.buffer.buffer,
             &self.core.image,
@@ -717,7 +727,7 @@ impl<B: hal::Backend> Image<B> {
             &[
                 hal::command::BufferImageCopy {
                     buffer_offset: self.upload_buffer.offset,
-                    buffer_width: size.width,
+                    buffer_width,
                     buffer_height: size.height,
                     image_layers: hal::image::SubresourceLayers {
                         aspects: hal::format::Aspects::COLOR,
@@ -749,7 +759,7 @@ impl<B: hal::Backend> Image<B> {
             );
         }
 
-        self.upload_buffer.offset += image_data.len() as u64;
+        self.upload_buffer.offset += offset as u64;
         cmd_buffer.finish()
     }
 
@@ -761,7 +771,7 @@ impl<B: hal::Backend> Image<B> {
 
 pub struct VertexDataImage<B: hal::Backend> {
     pub core: ImageCore<B>,
-    pub image_upload_buffer: Buffer<B>,
+    pub image_upload_buffer: CopyBuffer<B>,
     pub image_stride: usize,
     pub vecs_per_data: usize,
     pub image_width: u32,
@@ -775,6 +785,7 @@ impl<B: hal::Backend> VertexDataImage<B> {
         data_stride: usize,
         image_width: u32,
         image_height: u32,
+        pitch_alignment: usize,
     ) -> Self {
         let kind = hal::image::Kind::D2(
             image_width as hal::image::Size,
@@ -791,12 +802,14 @@ impl<B: hal::Backend> VertexDataImage<B> {
             hal::image::Usage::TRANSFER_DST | hal::image::Usage::SAMPLED,
             COLOR_RANGE,
         );
-        let image_upload_buffer = Buffer::create(
+        let image_upload_buffer = CopyBuffer::create(
             device,
             memory_types,
             hal::buffer::Usage::TRANSFER_SRC,
             data_stride,
-            (image_width * image_height) as usize,
+            image_width as usize,
+            image_height as usize,
+            pitch_alignment,
         );
         let image_stride = 4usize * mem::size_of::<f32>(); // Rgba32Float;
 
@@ -816,6 +829,7 @@ impl<B: hal::Backend> VertexDataImage<B> {
         cmd_pool: &mut hal::CommandPool<B, hal::queue::Graphics>,
         image_offset: DeviceUintPoint,
         image_data: &[T],
+        offset_alignment: usize,
     ) -> hal::command::Submit<B, hal::Graphics, hal::command::MultiShot, hal::command::Primary>
         where
             T: Copy,
@@ -827,10 +841,10 @@ impl<B: hal::Backend> VertexDataImage<B> {
         if needed_height > self.image_height {
             unimplemented!("TODO: implement resize");
         }
-        let buffer_width = (image_data_length as usize * self.image_upload_buffer.data_stride) as u64;
-        let buffer_offset = (image_offset.y * buffer_width as u32) as u64;
-        self.image_upload_buffer
-            .update(device, buffer_offset, buffer_width, image_data);
+        let image_data_width_in_bytes = (image_data_length as usize * self.image_upload_buffer.data_stride) as u64;
+        let buffer_offset = (image_offset.y as u64 * self.image_upload_buffer.row_pitch_in_bytes as u64);
+        assert_eq!(buffer_offset % (offset_alignment + 1) as u64, 0);
+        let _ = self.image_upload_buffer.update(device, buffer_offset, image_data_width_in_bytes, image_data, offset_alignment);
 
         let mut cmd_buffer = cmd_pool.acquire_command_buffer(false);
 
@@ -957,6 +971,128 @@ impl<B: hal::Backend> Buffer<B> {
             data[i] = *d;
         }
         device.release_mapping_writer(data);
+    }
+
+    fn transit(
+        &self,
+        access: hal::buffer::Access,
+    ) -> Option<hal::memory::Barrier<B>> {
+        let src_state = self.state.get();
+        if src_state == access {
+            None
+        } else {
+            self.state.set(access);
+            Some(hal::memory::Barrier::Buffer {
+                states: src_state .. access,
+                target: &self.buffer,
+            })
+        }
+    }
+
+    pub fn deinit(self, device: &B::Device) {
+        device.destroy_buffer(self.buffer);
+        device.free_memory(self.memory);
+    }
+}
+
+pub struct CopyBuffer<B: hal::Backend> {
+    pub memory: B::Memory,
+    pub buffer: B::Buffer,
+    pub data_stride: usize,
+    pub data_width: usize,
+    pub data_height: usize,
+    pub row_pitch_in_bytes: usize,
+    state: Cell<hal::buffer::State>,
+}
+
+impl<B: hal::Backend> CopyBuffer<B> {
+    pub fn create(
+        device: &B::Device,
+        memory_types: &[hal::MemoryType],
+        usage: hal::buffer::Usage,
+        data_stride: usize,
+        data_width: usize, // without stride
+        data_height: usize,
+        pitch_alignment: usize,
+    ) -> Self {
+        let mut row_pitch_in_bytes = (data_width * data_stride + pitch_alignment) & !pitch_alignment;
+        if row_pitch_in_bytes % data_width > 0 {
+            row_pitch_in_bytes = ((data_width + pitch_alignment) & !pitch_alignment) * data_stride;
+        }
+        let buffer_size = row_pitch_in_bytes * data_height;
+        let unbound_buffer = device.create_buffer(buffer_size as u64, usage).unwrap();
+        let requirements = device.get_buffer_requirements(&unbound_buffer);
+        let mem_type = memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, mt)| {
+                requirements.type_mask & (1 << id) != 0 &&
+                    mt.properties.contains(hal::memory::Properties::CPU_VISIBLE)
+                //&&!mt.properties.contains(memory::Properties::CPU_CACHED)
+            })
+            .unwrap()
+            .into();
+        let memory = device
+            .allocate_memory(mem_type, requirements.size)
+            .unwrap();
+        let buffer = device
+            .bind_buffer_memory(&memory, 0, unbound_buffer)
+            .unwrap();
+        CopyBuffer {
+            memory,
+            buffer,
+            data_stride,
+            data_width,
+            data_height,
+            row_pitch_in_bytes,
+            state: Cell::new(hal::buffer::Access::empty())
+        }
+    }
+
+    pub fn update<T>(
+        &mut self,
+        device: &B::Device,
+        buffer_offset: u64,
+        image_data_width_in_bytes: u64,
+        image_data: &[T],
+        offset_alignment: usize,
+    ) -> usize
+    where
+        T: Copy,
+    {
+        //assert!(self.state.get().contains(hal::buffer::Access::HOST_WRITE));
+        let buffer_data_width_in_bytes = self.data_width * self.data_stride;
+        let mut needed_height = image_data_width_in_bytes / buffer_data_width_in_bytes as u64;
+        let last_row_length = image_data_width_in_bytes % buffer_data_width_in_bytes as u64;
+        let range = if last_row_length != 0 {
+            needed_height += 1;
+            buffer_offset ..
+                buffer_offset + ((needed_height - 1) as usize * self.row_pitch_in_bytes) as u64 + last_row_length
+        } else {
+            buffer_offset .. (buffer_offset + (needed_height as usize * self.row_pitch_in_bytes) as u64)
+        };
+
+        let mut data = device
+            .acquire_mapping_writer::<T>(
+                &self.memory,
+                range,
+            )
+            .unwrap();
+
+        for y in 0 .. needed_height as usize {
+            let lower_bound = y * self.data_width;
+            let upper_bound = cmp::min(lower_bound + self.data_width, image_data.len());
+            let row = &(*image_data)[lower_bound .. upper_bound];
+            let dest_base = y * self.row_pitch();
+            data[dest_base .. dest_base + row.len()].copy_from_slice(row);
+        }
+        device.release_mapping_writer(data);
+        (needed_height as usize * self.row_pitch() + offset_alignment) & !offset_alignment
+    }
+
+    fn row_pitch(&self) -> usize {
+        assert_eq!(self.row_pitch_in_bytes % self.data_stride, 0);
+        self.row_pitch_in_bytes / self.data_stride
     }
 
     fn transit(
@@ -1252,7 +1388,7 @@ impl<B: hal::Backend> Program<B> {
             vertex_buffer_len,
         );
 
-        vertex_buffer.update(device, 0, vertex_buffer_len as u64, &vec![QUAD]);
+        vertex_buffer.update(device, 0, vertex_buffer_len as u64, &QUAD);
 
         let instance_buffer_stride = match *shader_kind {
             ShaderKind::Primitive |
@@ -1740,7 +1876,6 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
         surface: &mut <B as hal::Backend>::Surface,
         api_capabilities: ApiCapabilities,
     ) -> Self {
-        let max_texture_size = 4096u32;
         let renderer_name = "WIP".to_owned();
 
         let features = adapter.physical_device.features();
@@ -1773,6 +1908,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
         let limits = adapter
             .physical_device
             .limits();
+        let max_texture_size = 4096u32;
 
         let upload_memory_type: hal::MemoryTypeId = memory_types
             .iter()
@@ -1969,6 +2105,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             mem::size_of::<[f32; 4]>(),
             MAX_VERTEX_TEXTURE_WIDTH as u32,
             MAX_VERTEX_TEXTURE_WIDTH as u32,
+            (limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         let render_tasks = VertexDataImage::create(
@@ -1977,6 +2114,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             mem::size_of::<[f32; 12]>(),
             RENDER_TASK_TEXTURE_WIDTH as u32,
             TEXTURE_HEIGHT as u32,
+            (limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         let local_clip_rects = VertexDataImage::create(
@@ -1985,6 +2123,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             mem::size_of::<[f32; 4]>(),
             CLIP_RECTS_TEXTURE_WIDTH as u32,
             TEXTURE_HEIGHT as u32,
+            (limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         let node_data = VertexDataImage::create(
@@ -1993,6 +2132,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             mem::size_of::<[f32; 36]>(),
             NODE_TEXTURE_WIDTH as u32,
             TEXTURE_HEIGHT as u32,
+            (limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         Device {
@@ -2062,6 +2202,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                 &mut self.command_pool,
                 rect.origin,
                 gpu_data,
+                (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
             ));
     }
 
@@ -2072,6 +2213,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                 &mut self.command_pool,
                 DeviceUintPoint::zero(),
                 task_data,
+                (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
             ));
     }
 
@@ -2082,6 +2224,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                 &mut self.command_pool,
                 DeviceUintPoint::zero(),
                 local_data,
+                (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
             ));
     }
 
@@ -2092,6 +2235,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                 &mut self.command_pool,
                 DeviceUintPoint::zero(),
                 node_data,
+                (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
             ));
     }
 
@@ -2613,6 +2757,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             texture.width,
             texture.height,
             texture.layer_count,
+            (self.limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         assert_eq!(texture.fbo_ids.len(), 0);
@@ -2677,6 +2822,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                             ),
                             0,
                             data,
+                            (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
                         )
                 );
         }
@@ -2919,6 +3065,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                         rect,
                         layer_index,
                         data,
+                        (self.limits.min_buffer_copy_offset_alignment - 1) as usize,
                     )
             );
     }
@@ -2949,12 +3096,14 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
         let size_in_bytes = (bytes_per_pixel * rect.size.width * rect.size.height) as usize;
         assert_eq!(output.len(), size_in_bytes);
         let image = &self.frame_images[self.current_frame_id];
-        let download_buffer: Buffer<B> = Buffer::create(
+        let download_buffer: CopyBuffer<B> = CopyBuffer::create(
             &self.device,
             &self.memory_types,
             hal::buffer::Usage::TRANSFER_DST,
-            bytes_per_pixel as usize,
-            (rect.size.width * rect.size.height) as usize,
+            1,
+            (rect.size.width * bytes_per_pixel) as usize,
+            rect.size.height as usize,
+            (self.limits.min_buffer_copy_pitch_alignment - 1) as usize,
         );
 
         let copy_submit = {


### PR DESCRIPTION
This reverts commit a86d7a6e00137a7ad1a891c1b3909536fea73411.

I know we no longer need this for dx12 to work, but it's still an optimization, at least this is what 
 https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceLimits.html states:

> optimalBufferCopyRowPitchAlignment is the optimal buffer row pitch alignment in bytes for
vkCmdCopyBufferToImage and vkCmdCopyImageToBuffer. Row pitch is the number of bytes between
texels with the same X coordinate in adjacent rows (Y coordinates differ by one). The per texel
alignment requirements are enforced, but applications should use the optimal alignment
for optimal performance and power use.
