### PR TITLE
Fix horizontal blurs

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3201,7 +3201,7 @@ impl<B: hal::Backend> Renderer<B> {
                     &self.device,
                     projection,
                     0,
-                    &target.vertical_blurs.iter().map(|hb| hb.into()).collect::<Vec<BlurInstance>>(),
+                    &target.horizontal_blurs.iter().map(|hb| hb.into()).collect::<Vec<BlurInstance>>(),
                 );
                 self.device.draw(program);
                 stats.total_draw_calls += 1;


### PR DESCRIPTION
We had a typo when we bound the instances for the horizontal blurs. This fixes some test cases using blur (they look like the reference image).