### PR TITLE
Fix Cargo files and features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,8 +508,14 @@ dependencies = [
 name = "gfx-backend-empty"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#d09e24dc951a19b0561d384c15d88275afb29851"
+replace = "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)"
+
+[[package]]
+name = "gfx-backend-empty"
+version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5#b75b8f5e5db8983eb55363a41c58bd55312f9c9b"
 dependencies = [
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)",
 ]
 
 [[package]]
@@ -1773,6 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
+"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=b75b8f5)" = "<none>"
 "checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ panic = "abort"
 "https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5"}
 "https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0"= { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5" }
 "https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0"= { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-empty:0.1.0"= { git = "https://github.com/gfx-rs/gfx.git", rev="b75b8f5" }

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -13,8 +13,8 @@ profiler = ["thread_profiler/thread_profiler"]
 debugger = ["ws", "serde_json", "image", "base64"]
 capture = ["webrender_api/serialize"]
 replay = ["webrender_api/deserialize"]
-vulkan = ["gfx-backend-vulkan"]
-dx12 = ["gfx-backend-dx12"]
+vulkan = [] # for the examples
+dx12 = []   # for the examples
 
 [dependencies]
 app_units = "0.6"
@@ -43,14 +43,14 @@ ron = { version = "0.1.7" }
 winit = "0.11"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx.git" }
 rand = "0.4"
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx.git", optional = true }
 
 [dev-dependencies]
 mozangle = "0.1"
 env_logger = "0.5"
 rand = "0.3"                # for the benchmarks
 glutin = "0.12"             # for the example apps
+gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git" }
+gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx.git" }
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
 freetype = { version = "0.3", default-features = false }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -2693,7 +2693,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             }
         }
         // TODO remove this cfg if other platforms are supported
-        if cfg!(feature = "vulkan") && src_rect.size != dest_rect.size {
+        if src_rect.size != dest_rect.size {
             cmd_buffer.blit_image(
                 &src_img.image,
                 hal::image::ImageLayout::TransferSrcOptimal,


### PR DESCRIPTION
I removed the `cfg!(feature = "vulkan")` from `device.rs`, because with the current configuration we skip the `blit_image` call on Vulkan too and that is wrong. Plus we should not have backend specific cfg!-s in WebRender anymore. This removal causes a crash on dx12, because `blit_image` is unimplemented there, but we can fix this with a workaround (e.g. storing the rendering API type in an enum in `Device`) until other platforms get supported.