### PR TITLE
Store rendering API capabilities in Device

### DIFF
--- a/webrender/examples/common/boilerplate_hal.rs
+++ b/webrender/examples/common/boilerplate_hal.rs
@@ -14,6 +14,7 @@ use std::env;
 use std::path::PathBuf;
 use webrender;
 use webrender::api::*;
+use webrender::ApiCapabilities;
 use winit;
 
 use self::gfx_hal::Instance;
@@ -110,6 +111,12 @@ pub fn main_wrapper<E: Example>(
 
     let device_pixel_ratio = window.hidpi_factor();
     println!("Loading shaders...");
+
+    let mut api_capabilities = ApiCapabilities::empty();
+    if cfg!(feature = "vulkan") {
+        api_capabilities.insert(ApiCapabilities::BLITTING);
+    }
+
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,
         debug: true,
@@ -117,6 +124,7 @@ pub fn main_wrapper<E: Example>(
         device_pixel_ratio,
         clear_color: Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
         scatter_gpu_cache_updates: false,
+        api_capabilities,
         ..options.unwrap_or(webrender::RendererOptions::default())
     };
 

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -350,6 +350,12 @@ pub struct Capabilities {
     pub supports_multisampling: bool,
 }
 
+bitflags!(
+    pub struct ApiCapabilities: u8 {
+        const BLITTING = 0x1;
+    }
+);
+
 #[derive(Clone, Debug)]
 pub enum ShaderError {
     Compilation(String, String), // name, error mssage
@@ -1719,6 +1725,7 @@ pub struct Device<B: hal::Backend, C> {
 
     // Supported features
     features: hal::Features,
+    api_capabilities: ApiCapabilities,
 }
 
 impl<B: hal::Backend> Device<B, hal::Graphics> {
@@ -1729,6 +1736,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
         window: &winit::Window,
         adapter: hal::Adapter<B>,
         surface: &mut <B as hal::Backend>::Surface,
+        api_capabilities: ApiCapabilities,
     ) -> Self {
         let max_texture_size = 4096u32;
         let renderer_name = "WIP".to_owned();
@@ -2034,6 +2042,7 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
             //cached_programs,
             frame_id: FrameId(0),
             features,
+            api_capabilities,
         }
     }
 
@@ -2692,8 +2701,8 @@ impl<B: hal::Backend> Device<B, hal::Graphics> {
                 );
             }
         }
-        // TODO remove this cfg if other platforms are supported
-        if src_rect.size != dest_rect.size {
+        // TODO remove the first condition if other platforms are supported
+        if self.api_capabilities.contains(ApiCapabilities::BLITTING) && src_rect.size != dest_rect.size {
             cmd_buffer.blit_image(
                 &src_img.image,
                 hal::image::ImageLayout::TransferSrcOptimal,

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -170,7 +170,7 @@ extern crate png;
 pub extern crate webrender_api;
 
 #[doc(hidden)]
-pub use device::{ReadPixelsFormat, UploadMethod, VertexUsageHint};
+pub use device::{ApiCapabilities, ReadPixelsFormat, UploadMethod, VertexUsageHint};
 pub use renderer::{CpuProfile, DebugFlags, GpuProfile, OutputImageHandler, RendererKind};
 pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, Renderer, RendererOptions};

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -28,8 +28,8 @@ use debug_colors;
 use debug_render::DebugRenderer;
 #[cfg(feature = "debugger")]
 use debug_server::{self, DebugServer};
-use device::{BlurInstance, ClipMaskInstance, DepthFunction, Device, FrameId, Program, UploadMethod, Texture,
-             VertexDescriptor, PBO};
+use device::{ApiCapabilities, BlurInstance, ClipMaskInstance, DepthFunction, Device, FrameId, Program, UploadMethod,
+             Texture, VertexDescriptor, PBO};
 use device::{ExternalTexture, FBOId, TextureSlot, VertexAttribute, VertexAttributeKind};
 use device::{FileWatcherHandler, ShaderError, TextureFilter, VertexUsageHint};
 use device::{PipelineRequirements, PrimitiveInstance, ReadPixelsFormat, ShaderKind, VertexArrayKind};
@@ -1620,6 +1620,7 @@ impl<B: hal::Backend> Renderer<B> {
             window,
             adapter,
             surface,
+            options.api_capabilities,
         );
 
         let file =
@@ -4557,6 +4558,7 @@ pub struct RendererOptions {
     pub debug_flags: DebugFlags,
     pub renderer_id: Option<u64>,
     pub disable_dual_source_blending: bool,
+    pub api_capabilities: ApiCapabilities,
 }
 
 impl Default for RendererOptions {
@@ -4589,6 +4591,7 @@ impl Default for RendererOptions {
             renderer_id: None,
             //cached_programs: None,
             disable_dual_source_blending: false,
+            api_capabilities: ApiCapabilities::empty(),
         }
     }
 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex};
 use time;
 use webrender;
 use webrender::api::*;
-use webrender::{DebugFlags, RendererStats};
+use webrender::{ApiCapabilities, DebugFlags, RendererStats};
 use winit::EventsLoopProxy;
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use {WindowWrapper, BLACK_COLOR, WHITE_COLOR};
@@ -205,6 +205,11 @@ impl Wrench {
         debug_flags.set(DebugFlags::DISABLE_BATCHING, no_batch);
         let callbacks = Arc::new(Mutex::new(blob::BlobCallbacks::new()));
 
+        let mut api_capabilities = ApiCapabilities::empty();
+        if cfg!(feature = "vulkan") {
+            api_capabilities.insert(ApiCapabilities::BLITTING);
+        }
+
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dp_ratio,
             resource_override_path: shader_override_path,
@@ -217,6 +222,7 @@ impl Wrench {
             precache_shaders,
             blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new(callbacks.clone()))),
             disable_dual_source_blending,
+            api_capabilities,
             ..Default::default()
         };
 


### PR DESCRIPTION
Temporary workaround for the blitting issue in https://github.com/szeged/webrender/issues/134.

Added a new `RenderingApi` enum in which we can store the kind of the rendering API kind. It's value is set outside the WebRender crate and passed down in `RendererOptions` to the `Device` which stores it. In `Device` we use it to determine, if we can use `blit_image` with the current backend.