### PR TITLE
Fix remaining issues

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4101,7 +4101,7 @@ impl Default for RendererOptions {
             renderer_kind: RendererKind::Native,
             enable_subpixel_aa: false,
             clear_color: Some(ColorF::new(1.0, 1.0, 1.0, 1.0)),
-            enable_clear_scissor: true,
+            enable_clear_scissor: false,
             max_texture_size: None,
             // Scattered GPU cache updates haven't met a test that would show their superiority yet.
             scatter_gpu_cache_updates: false,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2556,11 +2556,11 @@ impl<B: hal::Backend> Renderer<B> {
 
         // Need to invert the y coordinates and flip the image vertically when
         // reading back from the framebuffer.
-        if render_target.is_none() {
+        /*if render_target.is_none() {
             src.origin.y = framebuffer_size.height as i32 - src.size.height - src.origin.y;
             dest.origin.y += dest.size.height;
             dest.size.height = -dest.size.height;
-        }
+        }*/
 
         self.device.bind_read_target(render_target);
         self.device.blit_render_target(src, dest);


### PR DESCRIPTION
I missed two things
- We inverted the main framebuffer to match vulkan/gfx, but forget to remove the inversion at readback
-  We currently not supporting the scissor at clear, so the default should be disabled