### PR TITLE
Remove warnings

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -175,7 +175,7 @@ fn write_shaders(glsl_files: Vec<PathBuf>, shader_file_path: &Path) -> HashMap<S
     write!(shader_file, "lazy_static! {{\n").unwrap();
     write!(
         shader_file,
-        "  pub static ref SHADERS: HashMap<&'static str, &'static str> = {{\n"
+        "  pub static ref _SHADERS: HashMap<&'static str, &'static str> = {{\n"
     ).unwrap();
     write!(shader_file, "    let mut h = HashMap::new();\n").unwrap();
     for glsl in glsl_files {

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -53,7 +53,6 @@ extern crate cfg_if;
 //#[cfg(any(feature = "debugger", feature = "capture", feature = "replay"))]
 #[macro_use]
 extern crate serde;
-#[macro_use]
 pub extern crate gfx_hal as hal;
 extern crate rand;
 
@@ -93,7 +92,7 @@ mod picture;
 mod prim_store;
 mod print_tree;
 mod profiler;
-mod query;
+//mod query;
 mod record;
 mod render_backend;
 mod render_task;

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::ColorF;
-use query::{GpuTimer, NamedTag};
+//use query::{GpuTimer, NamedTag};
 use std::collections::vec_deque::VecDeque;
 use std::f32;
 use time::precise_time_ns;
@@ -13,7 +13,7 @@ cfg_if! {
         use api::ColorU;
         use debug_render::DebugRenderer;
         use euclid::{Point2D, Rect, Size2D, vec2};
-        use query::GpuSampler;
+        //use query::GpuSampler;
         use internal_types::FastHashMap;
         use renderer::MAX_VERTEX_TEXTURE_WIDTH;
         use std::mem;
@@ -38,11 +38,11 @@ pub struct GpuProfileTag {
     pub color: ColorF,
 }
  
-impl NamedTag for GpuProfileTag {
+/*impl NamedTag for GpuProfileTag {
     fn get_label(&self) -> &str {
         self.label
     }
-}
+}*/
 
 trait ProfileCounter {
     fn description(&self) -> &'static str;
@@ -462,7 +462,7 @@ pub struct RendererProfileCounters {
 pub struct RendererProfileTimers {
     pub cpu_time: TimeProfileCounter,
     pub gpu_time: TimeProfileCounter,
-    pub gpu_samples: Vec<GpuTimer<GpuProfileTag>>,
+    //pub gpu_samples: Vec<GpuTimer<GpuProfileTag>>,
 }
 
 impl RendererProfileCounters {
@@ -490,7 +490,7 @@ impl RendererProfileTimers {
     pub fn new() -> Self {
         RendererProfileTimers {
             cpu_time: TimeProfileCounter::new("Compositor CPU Time", false),
-            gpu_samples: Vec::new(),
+            //gpu_samples: Vec::new(),
             gpu_time: TimeProfileCounter::new("GPU Time", false),
         }
     }
@@ -654,7 +654,7 @@ impl ProfileCounter for ProfileGraph {
 #[cfg(feature = "debug_renderer")]
 struct GpuFrame {
     total_time: u64,
-    samples: Vec<GpuTimer<GpuProfileTag>>,
+    //samples: Vec<GpuTimer<GpuProfileTag>>,
 }
 
 #[cfg(feature = "debug_renderer")]
@@ -670,13 +670,13 @@ impl GpuFrameCollection {
         }
     }
 
-    fn push(&mut self, total_time: u64, samples: Vec<GpuTimer<GpuProfileTag>>) {
+    fn push(&mut self, total_time: u64/*, samples: Vec<GpuTimer<GpuProfileTag>>*/) {
         if self.frames.len() == 20 {
             self.frames.pop_back();
         }
         self.frames.push_front(GpuFrame {
             total_time,
-            samples,
+            //samples,
         });
     }
 }

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -13,10 +13,10 @@ use euclid::{Transform3D};
 use glyph_rasterizer::GlyphFormat;
 use hal;
 use renderer::{
-    desc,
-    MAX_VERTEX_TEXTURE_WIDTH,
+    //desc,
+    //MAX_VERTEX_TEXTURE_WIDTH,
     BlendMode, ImageBufferKind, RendererError, RendererOptions,
-    TextureSampler,
+    //TextureSampler,
 };
 use ron::de::from_reader;
 use std::collections::HashMap;
@@ -24,11 +24,11 @@ use std::fs::File;
 use util::TransformedRectKind;
 
 //use gleam::gl::GlType;
-use time::precise_time_ns;
+//use time::precise_time_ns;
 
 
 impl ImageBufferKind {
-    pub(crate) fn get_feature_string(&self) -> &'static str {
+    pub(crate) fn _get_feature_string(&self) -> &'static str {
         match *self {
             ImageBufferKind::Texture2D => "TEXTURE_2D",
             ImageBufferKind::Texture2DArray => "",
@@ -48,16 +48,16 @@ impl ImageBufferKind {
     }*/
 }
 
-pub const IMAGE_BUFFER_KINDS: [ImageBufferKind; 4] = [
+pub const _IMAGE_BUFFER_KINDS: [ImageBufferKind; 4] = [
     ImageBufferKind::Texture2D,
     ImageBufferKind::TextureRect,
     ImageBufferKind::TextureExternal,
     ImageBufferKind::Texture2DArray,
 ];
 
-const TRANSFORM_FEATURE: &str = "TRANSFORM";
-const ALPHA_FEATURE: &str = "ALPHA_PASS";
-const DITHERING_FEATURE: &str = "DITHERING";
+const _TRANSFORM_FEATURE: &str = "TRANSFORM";
+const _ALPHA_FEATURE: &str = "ALPHA_PASS";
+const _DITHERING_FEATURE: &str = "DITHERING";
 
 
 pub struct LazilyCompiledShader {
@@ -72,12 +72,12 @@ impl LazilyCompiledShader {
         kind: ShaderKind,
         name: &'static str,
         pipeline_requirements: &mut HashMap<String, PipelineRequirements>,
-        device: &mut Device<B>,
+        _device: &mut Device<B>,
         precache: bool,
     ) -> Result<Self, ShaderError> {
         let pipeline_requirements =
             pipeline_requirements.remove(name).expect(&format!("Pipeline requirements not found for: {}", name));
-        let mut shader = LazilyCompiledShader {
+        let shader = LazilyCompiledShader {
             program: None,
             name,
             kind,

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -88,16 +88,19 @@ use reftest::{ReftestHarness, ReftestOptions};
 use std::ffi::CString;
 #[cfg(feature = "headless")]
 use std::mem;
+#[cfg(feature = "gl")]
 use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
 use std::process;
+#[cfg(feature = "gl")]
 use std::ptr;
+#[cfg(feature = "gl")]
 use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use webrender::DebugFlags;
 use webrender::api::*;
 #[cfg(not(feature = "gl"))]
-use winit::{ElementState, VirtualKeyCode, EventsLoop, EventsLoopProxy};
+use winit::VirtualKeyCode;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
@@ -175,7 +178,7 @@ impl HeadlessContext {
         unsafe { mem::transmute(osmesa_sys::OSMesaGetProcAddress(c_str.as_ptr())) }
     }
 
-    #[cfg(not(all(feature = "headless", feature = "gl")))]
+    #[cfg(all(not(feature = "headless"), feature = "gl"))]
     fn get_proc_address(_: &str) -> *const c_void {
         ptr::null() as *const _
     }
@@ -413,10 +416,10 @@ fn make_window(
 #[cfg(not(feature = "gl"))]
 fn make_window(
     size: DeviceUintSize,
-    dp_ratio: Option<f32>,
-    vsync: bool,
+    _dp_ratio: Option<f32>,
+    _vsync: bool,
     events_loop: &Option<winit::EventsLoop>,
-    angle: bool,
+    _angle: bool,
 ) -> WindowWrapper {
     match *events_loop {
         Some(ref events_loop) => {

--- a/wrench/src/perf.rs
+++ b/wrench/src/perf.rs
@@ -11,7 +11,10 @@ use std::io::{BufRead, BufReader};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Receiver;
-use wrench::{Wrench, WrenchThing};
+use wrench::{Wrench};
+#[cfg(feature = "gl")]
+use wrench::{WrenchThing};
+#[cfg(feature = "gl")]
 use yaml_frame_reader::YamlFrameReader;
 
 const COLOR_DEFAULT: &str = "\x1b[0m";
@@ -19,7 +22,9 @@ const COLOR_RED: &str = "\x1b[31m";
 const COLOR_GREEN: &str = "\x1b[32m";
 const COLOR_MAGENTA: &str = "\x1b[95m";
 
+#[cfg(feature = "gl")]
 const MIN_SAMPLE_COUNT: usize = 50;
+#[cfg(feature = "gl")]
 const SAMPLE_EXCLUDE_COUNT: usize = 10;
 
 pub struct Benchmark {
@@ -122,14 +127,14 @@ impl Profile {
 }
 
 pub struct PerfHarness<'a> {
-    wrench: &'a mut Wrench,
-    window: &'a mut WindowWrapper,
-    rx: Receiver<NotifierEvent>,
+    _wrench: &'a mut Wrench,
+    _window: &'a mut WindowWrapper,
+    _rx: Receiver<NotifierEvent>,
 }
 
 impl<'a> PerfHarness<'a> {
     pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<NotifierEvent>) -> Self {
-        PerfHarness { wrench, window, rx }
+        PerfHarness { _wrench: wrench, _window: window, _rx: rx }
     }
 
     pub fn run(mut self, base_manifest: &Path, filename: &str) {
@@ -157,11 +162,11 @@ impl<'a> PerfHarness<'a> {
         while cpu_frame_profiles.len() < MIN_SAMPLE_COUNT ||
             gpu_frame_profiles.len() < MIN_SAMPLE_COUNT
         {
-            reader.do_frame(self.wrench);
-            self.rx.recv().unwrap();
-            self.wrench.render();
-            self.window.swap_buffers();
-            let (cpu_profiles, gpu_profiles) = self.wrench.get_frame_profiles();
+            reader.do_frame(self._wrench);
+            self._rx.recv().unwrap();
+            self._wrench.render();
+            self._window.swap_buffers();
+            let (cpu_profiles, gpu_profiles) = self._wrench.get_frame_profiles();
             cpu_frame_profiles.extend(cpu_profiles);
             gpu_frame_profiles.extend(gpu_profiles);
         }
@@ -230,6 +235,7 @@ impl<'a> PerfHarness<'a> {
     }
 }
 
+#[cfg(feature = "gl")]
 fn extract_sample<F, T>(profiles: &mut [T], f: F) -> u64
 where
     F: Fn(&T) -> u64,

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -29,7 +29,10 @@ use webrender::{ApiCapabilities, DebugFlags, RendererStats};
 #[cfg(not(feature = "gl"))]
 use winit::EventsLoopProxy;
 use yaml_frame_writer::YamlFrameWriterReceiver;
+#[cfg(feature = "gl")]
 use {WindowWrapper, NotifierEvent, BLACK_COLOR, WHITE_COLOR};
+#[cfg(not(feature = "gl"))]
+use NotifierEvent;
 
 // TODO(gw): This descriptor matches what we currently support for fonts
 //           but is quite a mess. We should at least document and
@@ -642,7 +645,7 @@ impl Wrench {
         self.api.send_transaction(self.document_id, txn);
     }
 
-
+    #[cfg(feature = "gl")]
     pub fn get_frame_profiles(
         &mut self,
     ) -> (Vec<webrender::CpuProfile>, Vec<webrender::GpuProfile>) {


### PR DESCRIPTION
Fix all the warnings in `webrender`.
With `wrench` we will have errors on the CI, because the `main()` is empty in this case. But with `vulkan` and `dx12` builds we have no warnings.
NOTE: There is a `gl` feature for wrench (this was introduced in the previous [rebase](https://github.com/szeged/webrender/pull/149/files#diff-824fbd421922a257b860bc7c078985d3R47)), which we use for keep the legacy OpenGL code in the scope for the future transition. But until we don't have a common API for the old and the new gfx code this won't compile.

Fixes https://github.com/szeged/webrender/issues/144