### PR TITLE
Restore DebugRenderer

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -563,14 +563,14 @@ fn create_vertex_buffer_descriptors(file_name: &str) -> Vec<VertexBufferDesc> {
     } else if file_name.starts_with("debug_color") {
         descriptors = vec![
             VertexBufferDesc {
-                stride: 16, // size of DebugColorVertex 4 * 4
+                stride: 28, // size of DebugColorVertex 3 * 4 + 4 * 4
                 rate: 0,
             },
         ];
     } else if file_name.starts_with("debug_font") {
         descriptors = vec![
             VertexBufferDesc {
-                stride: 32, // size of DebugFontVertex 8 * 4
+                stride: 44, // size of DebugFontVertex 3 * 4 + 2 * 4 * 4
                 rate: 0,
             },
         ];

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -7,6 +7,9 @@ extern crate ron;
 extern crate serde;
 extern crate gfx_hal;
 
+#[path = "src/vertex_types.rs"]
+mod vertex_types;
+
 use gfx_hal::pso::{AttributeDesc, DescriptorRangeDesc, DescriptorSetLayoutBinding};
 use gfx_hal::pso::{DescriptorType, Element, ShaderStageFlags, VertexBufferDesc};
 use gfx_hal::format::Format;
@@ -14,12 +17,14 @@ use ron::de::from_str;
 use ron::ser::{to_string_pretty, PrettyConfig};
 use std::cmp::max;
 use std::env;
+use std::collections::HashMap;
 use std::fs::{canonicalize, read_dir, File};
 use std::io::BufReader;
 use std::io::prelude::*;
-use std::collections::HashMap;
+use std::mem;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
+use vertex_types::*;
 
 const SHADER_IMPORT: &str = "#include ";
 const SHADER_KIND_FRAGMENT: &str = "#define WR_FRAGMENT_SHADER\n";
@@ -542,35 +547,35 @@ fn create_desciptor_range_descriptors(count: usize) -> Vec<DescriptorRangeDesc> 
 fn create_vertex_buffer_descriptors(file_name: &str) -> Vec<VertexBufferDesc> {
     let mut descriptors = vec![
         VertexBufferDesc {
-            stride: 12, // size of Vertex 3 * 4
+            stride: mem::size_of::<Vertex>() as _,
             rate: 0,
         }
     ];
     if file_name.starts_with("cs_blur") {
         descriptors.push(
             VertexBufferDesc {
-                stride: 12 + 32, // size of BlurInstance 3 * 4 + PrimitiveInstance 8 * 4
+                stride: mem::size_of::<BlurInstance>() as _,
                 rate: 1,
             }
         );
     } else if file_name.starts_with("cs_clip") {
         descriptors.push(
             VertexBufferDesc {
-                stride: 28, // size of ClipMaskInstance 3 * 4 + 4 * 4
+                stride: mem::size_of::<ClipMaskInstance>() as _,
                 rate: 1,
             }
         );
     } else if file_name.starts_with("debug_color") {
         descriptors = vec![
             VertexBufferDesc {
-                stride: 28, // size of DebugColorVertex 3 * 4 + 4 * 4
+                stride: mem::size_of::<DebugColorVertex>() as _,
                 rate: 0,
             },
         ];
     } else if file_name.starts_with("debug_font") {
         descriptors = vec![
             VertexBufferDesc {
-                stride: 44, // size of DebugFontVertex 3 * 4 + 2 * 4 * 4
+                stride: mem::size_of::<DebugFontVertex>() as _,
                 rate: 0,
             },
         ];
@@ -578,7 +583,7 @@ fn create_vertex_buffer_descriptors(file_name: &str) -> Vec<VertexBufferDesc> {
     } else {
         descriptors.push(
             VertexBufferDesc {
-                stride: 32, // size of PrimitiveInstance 8 * 4
+                stride: mem::size_of::<PrimitiveInstance>() as _,
                 rate: 1,
             }
         );

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -488,15 +488,16 @@ fn add_attribute_descriptors(
     vertex_offset: &mut u32,
 ) {
     let def = split_code(line);
+    let var_name = def[2].trim_right_matches(';');
     let (format, offset) = match def[1] {
         "int" => (Format::R8Int, 4),
         "ivec4" => (Format::Rgba32Int, 16),
         "vec2" => (Format::Rg32Float, 8),
         "vec3" => (Format::Rgb32Float, 12),
+        "vec4" if var_name == "aColor" => (Format::Rgba8Unorm, 4),
         "vec4" => (Format::Rgba32Float, 16),
         _ => unimplemented!(),
     };
-    let var_name = def[2].trim_right_matches(';');
     match var_name {
         "aColor" | "aColorTexCoord" | "aPosition" => {
             attribute_descriptors.push(

--- a/webrender/res/debug_font.glsl
+++ b/webrender/res/debug_font.glsl
@@ -9,11 +9,11 @@ varying vec4 vColor;
 
 #ifdef WR_VERTEX_SHADER
 in vec4 aColor;
-in vec4 aColorTexCoord;
+in vec2 aColorTexCoord;
 
 void main(void) {
     vColor = aColor;
-    vColorTexCoord = aColorTexCoord.xy;
+    vColorTexCoord = aColorTexCoord;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -63,14 +63,11 @@ pub struct DebugRenderer {
     font_vertices: Vec<DebugFontVertex>,
     font_indices: Vec<u32>,
     font_program: ProgramId,
-    //font_vao: VAO,
     font_texture: Texture,
 
     tri_vertices: Vec<DebugColorVertex>,
     tri_indices: Vec<u32>,
-    //tri_vao: VAO,
     line_vertices: Vec<DebugColorVertex>,
-    //line_vao: VAO,
     color_program: ProgramId,
 }
 
@@ -93,9 +90,6 @@ impl DebugRenderer {
                 &ShaderKind::DebugFont,
             );
 
-        // TODO: bind sampler
-        //device.bind_shader_samplers(&font_program, &[("sColor0", DebugSampler::Font)]);
-
         let pipeline_requirement_color =
             pipeline_requirements
                 .remove("debug_color")
@@ -107,10 +101,6 @@ impl DebugRenderer {
                 "debug_color",
                 &ShaderKind::DebugColor
             );
-
-        /*let font_vao = device.create_vao(&DESC_FONT);
-        let line_vao = device.create_vao(&DESC_COLOR);
-        let tri_vao = device.create_vao(&DESC_COLOR);*/
 
         let mut font_texture = device.create_texture(TextureTarget::Array, ImageFormat::R8);
         device.init_texture(
@@ -127,13 +117,10 @@ impl DebugRenderer {
             font_vertices: Vec::new(),
             font_indices: Vec::new(),
             line_vertices: Vec::new(),
-            //tri_vao,
             tri_vertices: Vec::new(),
             tri_indices: Vec::new(),
             font_program,
             color_program,
-            //font_vao,
-            //line_vao,
             font_texture,
         }
     }
@@ -142,9 +129,6 @@ impl DebugRenderer {
         device.delete_texture(self.font_texture);
         device.delete_program(self.font_program);
         device.delete_program(self.color_program);
-        /*device.delete_vao(self.tri_vao);
-        device.delete_vao(self.line_vao);
-        device.delete_vao(self.font_vao);*/
     }
 
     pub fn line_height(&self) -> f32 {
@@ -278,52 +262,29 @@ impl DebugRenderer {
             // Triangles
             if !self.tri_vertices.is_empty() {
                 device.bind_program(self.color_program);
-                device.set_uniforms(/*&self.color_program,*/ &projection);
+                device.set_uniforms(&projection);
                 device.update_indices(self.tri_indices.as_slice());
                 device.update_vertices(&self.tri_vertices);
                 device.draw();
-                //device.bind_vao(&self.tri_vao);
-                //device.update_vao_indices(&self.tri_vao, &self.tri_indices, VertexUsageHint::Dynamic);
-                //device.update_vao_main_vertices(
-                //    &self.tri_vao,
-                //    &self.tri_vertices,
-                //    VertexUsageHint::Dynamic,
-                //);
-                //device.draw_triangles_u32(0, self.tri_indices.len() as i32);
             }
 
             // Lines
             if !self.line_vertices.is_empty() {
                 device.bind_program(self.color_program);
-                device.set_uniforms(/*&self.color_program,*/ &projection);
+                device.set_uniforms(&projection);
                 device.update_vertices(&self.line_vertices);
                 device.draw();
-                //device.bind_vao(&self.line_vao);
-                //device.update_vao_main_vertices(
-                //    &self.line_vao,
-                //    &self.line_vertices,
-                //    VertexUsageHint::Dynamic,
-                //);
-                //device.draw_nonindexed_lines(0, self.line_vertices.len() as i32);
             }
 
             // Glyph
             if !self.font_indices.is_empty() {
                 device.bind_program(self.font_program);
-                device.set_uniforms(/*&self.font_program,*/ &projection);
+                device.set_uniforms(&projection);
                 device.bind_texture(DebugSampler::Font, &self.font_texture);
                 device.update_indices(self.font_indices.as_slice());
                 device.update_vertices(&self.font_vertices);
                 device.bind_textures();
                 device.draw();
-                //device.bind_vao(&self.font_vao);
-                //device.update_vao_indices(&self.font_vao, &self.font_indices, VertexUsageHint::Dynamic);
-                //device.update_vao_main_vertices(
-                //    &self.font_vao,
-                //    &self.font_vertices,
-                //    VertexUsageHint::Dynamic,
-                //);
-                //device.draw_triangles_u32(0, self.font_indices.len() as i32);
             }
         }
 

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ColorU, ColorF, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
+use api::{ColorU, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
 use debug_font_data;
-use device::{Device, ProgramId, Texture, TextureSlot, /*VertexDescriptor*/};
-use device::{PipelineRequirements, ShaderKind, TextureFilter, /*VertexAttribute, VertexAttributeKind*/};
+use device::{Device, ProgramId, Texture, TextureSlot};
+use device::{PipelineRequirements, ShaderKind, TextureFilter};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use hal;
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
@@ -27,57 +27,20 @@ impl Into<TextureSlot> for DebugSampler {
     }
 }
 
-/*const DESC_FONT: VertexDescriptor = VertexDescriptor {
-    vertex_attributes: &[
-        VertexAttribute {
-            name: "aPosition",
-            count: 2,
-            kind: VertexAttributeKind::F32,
-        },
-        VertexAttribute {
-            name: "aColor",
-            count: 4,
-            kind: VertexAttributeKind::U8Norm,
-        },
-        VertexAttribute {
-            name: "aColorTexCoord",
-            count: 2,
-            kind: VertexAttributeKind::F32,
-        },
-    ],
-    instance_attributes: &[],
-};
-
-const DESC_COLOR: VertexDescriptor = VertexDescriptor {
-    vertex_attributes: &[
-        VertexAttribute {
-            name: "aPosition",
-            count: 2,
-            kind: VertexAttributeKind::F32,
-        },
-        VertexAttribute {
-            name: "aColor",
-            count: 4,
-            kind: VertexAttributeKind::U8Norm,
-        },
-    ],
-    instance_attributes: &[],
-};*/
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct DebugFontVertex {
     pub x: f32,
     pub y: f32,
     z: f32,
-    pub color: ColorF,
+    pub color: ColorU,
     pub u: f32,
     pub v: f32,
 }
 
 impl DebugFontVertex {
     pub fn new(x: f32, y: f32, u: f32, v: f32, color: ColorU) -> DebugFontVertex {
-        DebugFontVertex { x, y, z: 0.0, color: color.into(), u, v }
+        DebugFontVertex { x, y, z: 0.0, color, u, v }
     }
 }
 
@@ -87,12 +50,12 @@ pub struct DebugColorVertex {
     pub x: f32,
     pub y: f32,
     z: f32,
-    pub color: ColorF,
+    pub color: ColorU,
 }
 
 impl DebugColorVertex {
     pub fn new(x: f32, y: f32, color: ColorU) -> DebugColorVertex {
-        DebugColorVertex { x, y, z: 0.0, color: color.into(), }
+        DebugColorVertex { x, y, z: 0.0, color, }
     }
 }
 

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -73,13 +73,11 @@ pub struct DebugFontVertex {
     pub color: ColorF,
     pub u: f32,
     pub v: f32,
-    s: f32,
-    t: f32,
 }
 
 impl DebugFontVertex {
     pub fn new(x: f32, y: f32, u: f32, v: f32, color: ColorU) -> DebugFontVertex {
-        DebugFontVertex { x, y, z: 0.0, color: color.into(), u, v, s: 0.0, t: 0.0 }
+        DebugFontVertex { x, y, z: 0.0, color: color.into(), u, v }
     }
 }
 

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -55,7 +55,7 @@ pub struct DebugColorVertex {
 
 impl DebugColorVertex {
     pub fn new(x: f32, y: f32, color: ColorU) -> DebugColorVertex {
-        DebugColorVertex { x, y, z: 0.0, color, }
+        DebugColorVertex { x, y, z: 0.0, color }
     }
 }
 
@@ -96,14 +96,14 @@ impl DebugRenderer {
         // TODO: bind sampler
         //device.bind_shader_samplers(&font_program, &[("sColor0", DebugSampler::Font)]);
 
-        let pipeline_requirement2 =
+        let pipeline_requirement_color =
             pipeline_requirements
                 .remove("debug_color")
                 .expect("Pipeline requirements not found for debug_color");
 
         let color_program = device
             .create_program(
-                pipeline_requirement2,
+                pipeline_requirement_color,
                 "debug_color",
                 &ShaderKind::DebugColor
             );

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -280,7 +280,7 @@ impl ExternalTexture {
 
 pub struct Texture {
     id: TextureId,
-    target: TextureTarget,
+    _target: TextureTarget,
     layer_count: i32,
     format: ImageFormat,
     width: u32,
@@ -335,7 +335,7 @@ impl Texture {
     pub fn into_external(mut self) -> ExternalTexture {
         let ext = ExternalTexture {
             id: self.id,
-            _target: self.target,
+            _target: self._target,
         };
         self.id = 0; // don't complain, moved out
         ext
@@ -2454,7 +2454,7 @@ impl<B: hal::Backend> Device<B> {
     ) -> Texture {
         Texture {
             id: 0,
-            target: target,
+            _target: target,
             width: 0,
             height: 0,
             layer_count: 0,
@@ -2977,7 +2977,7 @@ impl<B: hal::Backend> Device<B> {
 
     #[cfg(any(feature = "debug_renderer", feature="capture"))]
     pub fn attach_read_texture(&mut self, texture: &Texture, layer_id: i32) {
-        self.attach_read_texture_raw(texture.id, texture.target, layer_id)
+        self.attach_read_texture_raw(texture.id, texture._target, layer_id)
     }
 
     pub fn end_frame(&mut self) {

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -20,6 +20,7 @@ use std::ops::Add;
 use std::path::PathBuf;
 use std::slice;
 use std::thread;
+use vertex_types::*;
 
 use hal;
 
@@ -60,57 +61,10 @@ const ENTRY_NAME: &str = "main";
 
 #[derive(Debug, Clone, Copy)]
 #[allow(non_snake_case)]
-pub struct Vertex {
-    aPosition: [f32; 3],
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-pub struct DebugColorVertex {
-    aPosition: [f32; 3],
-    aColor: [f32; 4],
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-pub struct DebugFontVertex {
-    aPosition: [f32; 3],
-    aColor: [f32; 4],
-    aColorTexCoord: [f32; 4],
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-struct Locals {
+pub struct Locals {
     uTransform: [[f32; 4]; 4],
     uDevicePixelRatio: f32,
     uMode: i32,
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-pub struct PrimitiveInstance {
-    pub aData0: [i32; 4],
-    pub aData1: [i32; 4],
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-pub struct ClipMaskInstance {
-    pub aClipRenderTaskAddress: i32,
-    pub aScrollNodeId: i32,
-    pub aClipSegment: i32,
-    pub aClipDataResourceAddress: [i32; 4],
-}
-
-#[derive(Debug, Clone, Copy)]
-#[allow(non_snake_case)]
-pub struct BlurInstance {
-    pub aData0: [i32; 4],
-    pub aData1: [i32; 4],
-    pub aBlurRenderTaskAddress: i32,
-    pub aBlurSourceTaskAddress: i32,
-    pub aBlurDirection: i32,
 }
 
 #[derive(Clone, Deserialize)]

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1461,8 +1461,11 @@ impl<B: hal::Backend> Program<B> {
                 viewport.rect,
                 clear_values,
             );
-            //encoder.draw(0 .. 6, (self.instance_buffer.offset - self.instance_buffer.size) as u32 .. self.instance_buffer.offset as u32);
-            encoder.draw_indexed(0 .. (self.index_buffer.data_len / mem::size_of::<u32>()) as u32, 0, (self.instance_buffer.offset - self.instance_buffer.size) as u32 .. cmp::max(self.instance_buffer.offset, 1)as u32);
+            encoder.draw_indexed(
+                0 .. (self.index_buffer.data_len / self.index_buffer.data_stride) as u32,
+                0,
+                (self.instance_buffer.offset - self.instance_buffer.size) as u32 .. cmp::max(self.instance_buffer.offset, 1) as u32,
+            );
         }
 
         cmd_buffer.finish()
@@ -2169,8 +2172,7 @@ impl<B: hal::Backend> Device<B> {
         assert_ne!(self.bound_program, INVALID_PROGRAM_ID);
         let program = self.programs.get_mut(&self.bound_program).expect("Program not found.");
 
-        let index_buffer_stride = mem::size_of::<u32>();
-        let index_buffer_len = indices.len() * index_buffer_stride;
+        let index_buffer_len = indices.len() * program.index_buffer.data_stride;
         program.index_buffer.update(&self.device, 0, index_buffer_len as u64, &indices);
     }
 
@@ -2180,8 +2182,7 @@ impl<B: hal::Backend> Device<B> {
         assert_ne!(self.bound_program, INVALID_PROGRAM_ID);
         let program = self.programs.get_mut(&self.bound_program).expect("Program not found.");
 
-        let vertex_buffer_stride = mem::size_of::<T>();
-        let vertex_buffer_len = vertices.len() * vertex_buffer_stride;
+        let vertex_buffer_len = vertices.len() * program.vertex_buffer.data_stride;
         program.vertex_buffer.update(&self.device, 0, vertex_buffer_len as u64, &vertices);
     }
 

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -92,7 +92,7 @@ mod picture;
 mod prim_store;
 mod print_tree;
 mod profiler;
-//mod query;
+mod query;
 mod record;
 mod render_backend;
 mod render_task;

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -107,6 +107,7 @@ mod texture_allocator;
 mod texture_cache;
 mod tiling;
 mod util;
+mod vertex_types;
 
 mod shader_source {
     include!(concat!(env!("OUT_DIR"), "/shaders.rs"));

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -92,6 +92,7 @@ mod picture;
 mod prim_store;
 mod print_tree;
 mod profiler;
+#[cfg(feature = "debug_renderer")]
 mod query;
 mod record;
 mod render_backend;

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::ColorF;
-//use query::{GpuTimer, NamedTag};
+use query::{GpuTimer, NamedTag};
 use std::collections::vec_deque::VecDeque;
 use std::f32;
 use time::precise_time_ns;
@@ -13,7 +13,7 @@ cfg_if! {
         use api::ColorU;
         use debug_render::DebugRenderer;
         use euclid::{Point2D, Rect, Size2D, vec2};
-        //use query::GpuSampler;
+        use query::GpuSampler;
         use internal_types::FastHashMap;
         use renderer::MAX_VERTEX_TEXTURE_WIDTH;
         use std::mem;
@@ -38,11 +38,11 @@ pub struct GpuProfileTag {
     pub color: ColorF,
 }
  
-/*impl NamedTag for GpuProfileTag {
+impl NamedTag for GpuProfileTag {
     fn get_label(&self) -> &str {
         self.label
     }
-}*/
+}
 
 trait ProfileCounter {
     fn description(&self) -> &'static str;
@@ -462,7 +462,7 @@ pub struct RendererProfileCounters {
 pub struct RendererProfileTimers {
     pub cpu_time: TimeProfileCounter,
     pub gpu_time: TimeProfileCounter,
-    //pub gpu_samples: Vec<GpuTimer<GpuProfileTag>>,
+    pub gpu_samples: Vec<GpuTimer<GpuProfileTag>>,
 }
 
 impl RendererProfileCounters {
@@ -490,7 +490,7 @@ impl RendererProfileTimers {
     pub fn new() -> Self {
         RendererProfileTimers {
             cpu_time: TimeProfileCounter::new("Compositor CPU Time", false),
-            //gpu_samples: Vec::new(),
+            gpu_samples: Vec::new(),
             gpu_time: TimeProfileCounter::new("GPU Time", false),
         }
     }
@@ -654,7 +654,7 @@ impl ProfileCounter for ProfileGraph {
 #[cfg(feature = "debug_renderer")]
 struct GpuFrame {
     total_time: u64,
-    //samples: Vec<GpuTimer<GpuProfileTag>>,
+    samples: Vec<GpuTimer<GpuProfileTag>>,
 }
 
 #[cfg(feature = "debug_renderer")]
@@ -670,13 +670,13 @@ impl GpuFrameCollection {
         }
     }
 
-    fn push(&mut self, total_time: u64/*, samples: Vec<GpuTimer<GpuProfileTag>>*/) {
+    fn push(&mut self, total_time: u64, samples: Vec<GpuTimer<GpuProfileTag>>) {
         if self.frames.len() == 20 {
             self.frames.pop_back();
         }
         self.frames.push_front(GpuFrame {
             total_time,
-            //samples,
+            samples,
         });
     }
 }

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::ColorF;
+#[cfg(feature = "debug_renderer")]
 use query::{GpuTimer, NamedTag};
 use std::collections::vec_deque::VecDeque;
 use std::f32;
@@ -37,7 +38,8 @@ pub struct GpuProfileTag {
     pub label: &'static str,
     pub color: ColorF,
 }
- 
+
+#[cfg(feature = "debug_renderer")]
 impl NamedTag for GpuProfileTag {
     fn get_label(&self) -> &str {
         self.label
@@ -462,6 +464,7 @@ pub struct RendererProfileCounters {
 pub struct RendererProfileTimers {
     pub cpu_time: TimeProfileCounter,
     pub gpu_time: TimeProfileCounter,
+    #[cfg(feature = "debug_renderer")]
     pub gpu_samples: Vec<GpuTimer<GpuProfileTag>>,
 }
 
@@ -490,8 +493,9 @@ impl RendererProfileTimers {
     pub fn new() -> Self {
         RendererProfileTimers {
             cpu_time: TimeProfileCounter::new("Compositor CPU Time", false),
-            gpu_samples: Vec::new(),
             gpu_time: TimeProfileCounter::new("GPU Time", false),
+            #[cfg(feature = "debug_renderer")]
+            gpu_samples: Vec::new(),
         }
     }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -39,6 +39,7 @@ use internal_types::{RenderTargetInfo, SavedTargetIndex};
 use prim_store::DeferredResolve;
 use profiler::{BackendProfileCounters, FrameProfileCounters,
                GpuProfileTag, RendererProfileCounters, RendererProfileTimers};
+#[cfg(feature = "debug_renderer")]
 use query::GpuProfiler;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use record::ApiRecordingReceiver;

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -23,7 +23,7 @@ use debug_colors;
 use device::{DepthFunction, Device, FrameId, UploadMethod, Texture};
 use device::{ExternalTexture, FBOId, TextureSlot};
 use device::{FileWatcherHandler, ShaderError, TextureFilter, ReadPixelsFormat};
-use device::{ApiCapabilities, BlurInstance, ClipMaskInstance, PrimitiveInstance, VertexArrayKind};
+use device::{ApiCapabilities, VertexArrayKind};
 use euclid::{rect, Transform3D};
 use frame_builder::FrameBuilderConfig;
 //use gleam::gl;
@@ -68,6 +68,7 @@ use tiling::{Frame, RenderTarget, RenderTargetKind, ScalingInfo, TextureCacheRen
 #[cfg(not(feature = "pathfinder"))]
 use tiling::GlyphJob;
 use time::precise_time_ns;
+use vertex_types::{BlurInstance, ClipMaskInstance, PrimitiveInstance};
 
 use hal;
 

--- a/webrender/src/vertex_types.rs
+++ b/webrender/src/vertex_types.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct BlurInstance {
+    pub aData0: [i32; 4],
+    pub aData1: [i32; 4],
+    pub aBlurRenderTaskAddress: i32,
+    pub aBlurSourceTaskAddress: i32,
+    pub aBlurDirection: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct ClipMaskInstance {
+    pub aClipRenderTaskAddress: i32,
+    pub aScrollNodeId: i32,
+    pub aClipSegment: i32,
+    pub aClipDataResourceAddress: [i32; 4],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct DebugColorVertex {
+    aPosition: [f32; 3],
+    aColor: [f32; 4],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct DebugFontVertex {
+    aPosition: [f32; 3],
+    aColor: [f32; 4],
+    aColorTexCoord: [f32; 2],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct PrimitiveInstance {
+    pub aData0: [i32; 4],
+    pub aData1: [i32; 4],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case)]
+pub struct Vertex {
+    pub aPosition: [f32; 3],
+}

--- a/webrender/src/vertex_types.rs
+++ b/webrender/src/vertex_types.rs
@@ -25,14 +25,14 @@ pub struct ClipMaskInstance {
 #[allow(non_snake_case)]
 pub struct DebugColorVertex {
     aPosition: [f32; 3],
-    aColor: [f32; 4],
+    aColor: [u8; 4],
 }
 
 #[derive(Debug, Clone, Copy)]
 #[allow(non_snake_case)]
 pub struct DebugFontVertex {
     aPosition: [f32; 3],
-    aColor: [f32; 4],
+    aColor: [u8; 4],
     aColorTexCoord: [f32; 2],
 }
 


### PR DESCRIPTION
Fixes the third part of #150: restore DebugRenderer.
Added `DebugColor` and `DebugFont` shader kinds. These shaders are handled differently when creating programs, because they need index and vertex buffers with relative large [sizes](https://github.com/szeged/webrender/compare/master...zakorgy:restore-debug-renderer#diff-d058594280164bb23d9b1ca25ba9fe79R36) (these are the maximum values I got from upstream WebRender), and just one pipeline.
Also replaced `draw` with `draw_indexed` to support drawing with these shaders.

At the moment the `DebugRenderer` draws, but after we reach a certain number of indices/vertices the following vulkan validation layer error shows up:
`2018-05-03T12:24:58Z: gfx_backend_vulkan: [MEM] Object: 0x1779beb3980 | Number of currently valid memory objects is not less than the maximum allowed (4096).`
I'm not sure if this is caused by the high number of vertices/indices, or I missed something in the implementation.

