### PR TITLE
Restore TextureUploader

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1220,11 +1220,11 @@ impl CacheTexture {
                     return 0
                 }
 
-                /*let mut uploader = device.upload_texture(
+                let mut uploader = device.upload_texture(
                     &self.texture,
-                    buffer,
+                    //buffer,
                     rows_dirty * MAX_VERTEX_TEXTURE_WIDTH,
-                );*/
+                );
 
                 for (row_index, row) in rows.iter_mut().enumerate() {
                     if !row.is_dirty {
@@ -1239,9 +1239,7 @@ impl CacheTexture {
                         DeviceUintSize::new(MAX_VERTEX_TEXTURE_WIDTH as u32, 1),
                     );
 
-                    //uploader.upload(rect, 0, None, cpu_blocks);
-                    let data_blocks = cpu_blocks.iter().map(|block| block.data).collect::<Vec<[f32; 4]>>();
-                    device.upload_texture(&self.texture, rect, 0, None, &data_blocks);
+                    uploader.upload(rect, 0, None, cpu_blocks);
 
                     row.is_dirty = false;
                 }
@@ -1320,10 +1318,9 @@ impl VertexDataTexture {
             DeviceUintPoint::zero(),
             DeviceUintSize::new(width, needed_height),
         );
-        //device
-        //    .upload_texture(&self.texture, &self.pbo, 0)
-        //    .upload(rect, 0, None, data);
-        device.upload_texture(&self.texture, rect, 0, None, data.as_slice());
+        device
+            .upload_texture(&self.texture, /*&self.pbo,*/ 0)
+            .upload(rect, 0, None, data);
     }
 
     fn deinit<B: hal::Backend>(self, device: &mut Device<B>) {
@@ -2476,20 +2473,16 @@ impl<B: hal::Backend> Renderer<B> {
                         offset,
                     } => {
                         let texture = &self.texture_resolver.cache_texture_map[update.id.0];
-                        /*let mut uploader = self.device.upload_texture(
+                        let mut uploader = self.device.upload_texture(
                             texture,
-                            &self.texture_cache_upload_pbo,
+                            //&self.texture_cache_upload_pbo,
                             0,
-                        );*/
+                        );
 
                         match source {
                             TextureUpdateSource::Bytes { data } => {
-                                //uploader.upload(
-                                //    rect, layer_index, stride,
-                                //    &data[offset as usize ..],
-                                //);
-                                self.device.upload_texture(
-                                    texture, rect, layer_index, stride,
+                                uploader.upload(
+                                    rect, layer_index, stride,
                                     &data[offset as usize ..],
                                 );
                             }


### PR DESCRIPTION
Fixes: #148
My first attempt to restore the TextureUploader API.
The differences between the original API logic and this implementation:
- It uses PBO-s to upload textures, we have an upload buffer for each image to do the same. Since OpenGL doesn't have to know the size when creating these buffers, it can create PBO-s separately from textures. In our case we must know the size for the buffers and the image creation is when we receive this data.
-  It splits the buffer upload and the texture update in two separate steps. Since our upload buffers and images are paired together, we do the upload and update in the final step. If we want to follow the original API logic, we should move some input parameters between the buffer upload and texture update function .
- The original API doesn't need to store a reference to the data in the UploadChunk structure, because the data is uploaded to the corresponding PBO when we create an UploadChunk. We only upload it in the final step: `update_impl`, so until then we have store a [reference](https://github.com/szeged/webrender/compare/master...zakorgy:restore-texture-uploader#diff-d058594280164bb23d9b1ca25ba9fe79R3215) to the data in the UploadChunk.