### PR TITLE
Skip draw calls where the instance data is empty

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2541,6 +2541,10 @@ impl<B: hal::Backend> Renderer<B> {
     )
         where T: PrimitiveType
     {
+        if data.is_empty() {
+            return;
+        }
+
         for i in 0 .. textures.colors.len() {
             self.texture_resolver.bind(
                 &textures.colors[i],


### PR DESCRIPTION
Fixes
- WARN [ParameterValidation] Object: 0x0 | vkCmdDraw parameter, uint32_t instanceCount, is 0
- WARN [MEM] Object: 0x55 | vkCmdBindVertexBuffers(): Cannot read invalid region of memory allocation 0x55 for bound Buffer object 0x54, please fill the memory before using.