### PR TITLE
Change DashAndDot render_pass format

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1188,7 +1188,7 @@ impl<B: hal::Backend> Program<B> {
                 ],
             };
             let format = match *shader_kind {
-                ShaderKind::ClipCache => ImageFormat::R8,
+                ShaderKind::ClipCache | ShaderKind::Cache(VertexArrayKind::DashAndDot) => ImageFormat::R8,
                 ShaderKind::Cache(VertexArrayKind::Blur) if shader_name.contains("_alpha_target") => ImageFormat::R8,
                 _ => ImageFormat::BGRA8,
             };


### PR DESCRIPTION
Fixes `ERROR [DS] Object: 0x6 | vkCmdDraw(): RenderPasses incompatible between active render pass w/ renderPass 0x6 and pipeline state object w/ renderPass 0x8 Attachment 0 is not compatible with 0: They have different formats.. The spec valid usage text states 'The current render pass must be compatible with the renderPass member of the VkGraphicsPipelineCreateInfo structure specified when creating the VkPipeline currently bound to VK_PIPELINE_BIND_POINT_GRAPHICS.' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-vkCmdDraw-renderPass-00435)`

The other error mentioned [here](https://github.com/szeged/webrender/issues/80#issuecomment-388031368) is a bug in the shader. Fix: https://github.com/servo/webrender/pull/2746