### PR TITLE
Fix the layout qualifier indices in shaders

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -98,3 +98,13 @@ ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
 }
 
 #endif //WR_VERTEX_SHADER
+
+#ifdef WR_FRAGMENT_SHADER
+
+//Note: identical to prim_shared
+float distance_to_line(vec2 p0, vec2 perp_dir, vec2 p) {
+    vec2 dir_to_p0 = p0 - p;
+    return dot(normalize(perp_dir), dir_to_p0);
+}
+
+#endif //WR_FRAGMENT_SHADER

--- a/webrender/res/cs_border_segment.glsl
+++ b/webrender/res/cs_border_segment.glsl
@@ -24,7 +24,8 @@ in vec4 aRect;
 in vec4 aColor0;
 in vec4 aColor1;
 in int aFlags;
-in vec4 aWidthsRadii;
+in vec2 aWidths;
+in vec2 aRadii;
 
 #define SEGMENT_TOP_LEFT        0
 #define SEGMENT_TOP_RIGHT       1
@@ -62,8 +63,6 @@ vec2 get_outer_corner_scale(int segment) {
 
 void main(void) {
     vec2 pos = aRect.xy + aRect.zw * aPosition.xy;
-    vec2 widths = aWidthsRadii.xy;
-    vec2 radii = aWidthsRadii.zw;
 
     int segment = aFlags & 0xff;
     int style = (aFlags >> 8) & 0xff;
@@ -78,8 +77,8 @@ void main(void) {
 
     vFeatures = 0;
     vClipSign = clip_sign;
-    vClipCenter = outer + clip_sign * radii;
-    vClipRadii = vec4(radii, radii - widths);
+    vClipCenter = outer + clip_sign * aRadii;
+    vClipRadii = vec4(aRadii, aRadii - aWidths);
     vColorLine = vec4(0.0);
 
     switch (segment) {
@@ -88,7 +87,7 @@ void main(void) {
         case SEGMENT_BOTTOM_RIGHT:
         case SEGMENT_BOTTOM_LEFT:
             vFeatures |= (CLIP_RADII | MIX_COLOR);
-            vColorLine = vec4(outer, widths.y * -clip_sign.y, widths.x * clip_sign.x);
+            vColorLine = vec4(outer, aWidths.y * -clip_sign.y, aWidths.x * clip_sign.x);
             break;
         default:
             break;

--- a/webrender/res/cs_border_segment.glsl
+++ b/webrender/res/cs_border_segment.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include shared,rect,transform,ellipse
+#include shared,prim_shared,ellipse,shared_border
 
 flat varying vec4 vColor0;
 flat varying vec4 vColor1;

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -25,6 +25,11 @@ vec2 clamp_rect(vec2 pt, RectWithSize rect) {
     return clamp(pt, rect.p0, rect.p0 + rect.size);
 }
 
+float distance_to_line(vec2 p0, vec2 perp_dir, vec2 p) {
+    vec2 dir_to_p0 = p0 - p;
+    return dot(normalize(perp_dir), dir_to_p0);
+}
+
 // TODO: convert back to RectWithEndPoint if driver issues are resolved, if ever.
 flat varying vec4 vClipMaskUvBounds;
 varying vec3 vClipMaskUv;

--- a/webrender/res/transform.glsl
+++ b/webrender/res/transform.glsl
@@ -92,9 +92,4 @@ float init_transform_rough_fs(vec2 local_pos) {
     );
 }
 
-float distance_to_line(vec2 p0, vec2 perp_dir, vec2 p) {
-    vec2 dir_to_p0 = p0 - p;
-    return dot(normalize(perp_dir), dir_to_p0);
-}
-
 #endif //WR_FRAGMENT_SHADER

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -207,12 +207,15 @@ impl PrimitiveType for gpu_types::BorderInstance {
     type Primitive = BorderInstance;
     fn to_primitive_type(&self) -> BorderInstance {
         BorderInstance {
+            aData0: [0,0,0,0],
+            aData1: [0,0,0,0],
             aTaskOrigin: [self.task_origin.x, self.task_origin.y],
             aRect: [self.local_rect.origin.x, self.local_rect.origin.y, self.local_rect.size.width, self.local_rect.size.height],
             aColor0: self.color0.to_array(),
             aColor1: self.color1.to_array(),
             aFlags: self.flags,
-            aWidthsRadii: [self.widths.width, self.widths.height, self.radius.width, self.radius.height],
+            aWidths: [self.widths.width, self.widths.height],
+            aRadii: [self.radius.width, self.radius.height],
         }
     }
 }

--- a/webrender/src/vertex_types.rs
+++ b/webrender/src/vertex_types.rs
@@ -5,12 +5,15 @@
 #[derive(Debug, Clone, Copy)]
 #[allow(non_snake_case)]
 pub struct BorderInstance {
+    pub aData0: [i32; 4],
+    pub aData1: [i32; 4],
     pub aTaskOrigin: [f32; 2],
     pub aRect: [f32; 4],
     pub aColor0: [f32; 4],
     pub aColor1: [f32; 4],
     pub aFlags: i32,
-    pub aWidthsRadii: [f32; 4],
+    pub aWidths: [f32; 2],
+    pub aRadii: [f32; 2],
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
This PR fixes https://github.com/szeged/webrender/issues/180.
It turned out we only had to change the numbering of the layout qulifiers in the shaders.
Previously we assigned the location indices as we processed the shader file from the beginning and assigned the location indices incrementally.
Now we have the indices from 0 to 15 reserved for vertex in variables, and for the one or two fragment out varable(s). This way we should not exceed the `maxVertexInputAttributes` limit of Vulkan. The indexing of varying(vertex out, fragment in) variables starts from 16, because the index limitation for these variables is a greater value.