### PR TITLE
Use clear attachments for rectangle clears

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,16 +462,16 @@ dependencies = [
 name = "gfx-backend-dx12"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
+replace = "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)"
 
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003#e2f040d8ff0c903ba38f68aa301d041deb512003"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spirv_cross 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,30 +484,30 @@ dependencies = [
 name = "gfx-backend-empty"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
+replace = "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)"
 
 [[package]]
 name = "gfx-backend-empty"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003#e2f040d8ff0c903ba38f68aa301d041deb512003"
 dependencies = [
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)",
 ]
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
+replace = "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)"
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003#e2f040d8ff0c903ba38f68aa301d041deb512003"
 dependencies = [
  "ash 0.24.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -522,12 +522,12 @@ dependencies = [
 name = "gfx-hal"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
+replace = "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)"
 
 [[package]]
 name = "gfx-hal"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003#e2f040d8ff0c903ba38f68aa301d041deb512003"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1899,13 +1899,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
+"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)" = "<none>"
 "checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
+"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
+"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)" = "<none>"
 "checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
+"checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=e2f040d8ff0c903ba38f68aa301d041deb512003)" = "<none>"
 "checksum gif 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e41945ba23db3bf51b24756d73d81acb4f28d85c3dccc32c6fae904438c25f"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.4.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b4e5e2cdcadecdf3886e7808b6a38eae0a48dfe98c5c12b776fc861b80edf4a2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,16 +462,16 @@ dependencies = [
 name = "gfx-backend-dx12"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)"
+replace = "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
 
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73#8d2b93a8dfd9c99b7cbec703924a628d56cc9c73"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spirv_cross 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,30 +484,30 @@ dependencies = [
 name = "gfx-backend-empty"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)"
+replace = "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
 
 [[package]]
 name = "gfx-backend-empty"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73#8d2b93a8dfd9c99b7cbec703924a628d56cc9c73"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
 dependencies = [
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
 ]
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)"
+replace = "gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73#8d2b93a8dfd9c99b7cbec703924a628d56cc9c73"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
 dependencies = [
  "ash 0.24.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)",
+ "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -522,12 +522,12 @@ dependencies = [
 name = "gfx-hal"
 version = "0.1.0"
 source = "git+https://github.com/gfx-rs/gfx.git#eeb86030d12b3c87dafc49ba4b9eb0e1fb4e343b"
-replace = "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)"
+replace = "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)"
 
 [[package]]
 name = "gfx-hal"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73#8d2b93a8dfd9c99b7cbec703924a628d56cc9c73"
+source = "git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c#4553a393670502791c955f768fd2aea7e228c20c"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1899,13 +1899,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)" = "<none>"
+"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
 "checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)" = "<none>"
+"checksum gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
 "checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)" = "<none>"
+"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
 "checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git)" = "<none>"
-"checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=8d2b93a8dfd9c99b7cbec703924a628d56cc9c73)" = "<none>"
+"checksum gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx.git?rev=4553a393670502791c955f768fd2aea7e228c20c)" = "<none>"
 "checksum gif 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e41945ba23db3bf51b24756d73d81acb4f28d85c3dccc32c6fae904438c25f"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.4.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b4e5e2cdcadecdf3886e7808b6a38eae0a48dfe98c5c12b776fc861b80edf4a2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "abort"
 
 [replace]
 #"https://github.com/serde-rs/serde#serde_derive:1.0.58" = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums7", feature="deserialize_in_place" }
-"https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="8d2b93a8dfd9c99b7cbec703924a628d56cc9c73"}
-"https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="8d2b93a8dfd9c99b7cbec703924a628d56cc9c73" }
-"https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="8d2b93a8dfd9c99b7cbec703924a628d56cc9c73" }
-"https://github.com/gfx-rs/gfx.git#gfx-backend-empty:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="8d2b93a8dfd9c99b7cbec703924a628d56cc9c73" }
+"https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c"}
+"https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-empty:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "abort"
 
 [replace]
 #"https://github.com/serde-rs/serde#serde_derive:1.0.58" = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums7", feature="deserialize_in_place" }
-"https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c"}
-"https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }
-"https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }
-"https://github.com/gfx-rs/gfx.git#gfx-backend-empty:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="4553a393670502791c955f768fd2aea7e228c20c" }
+"https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003"}
+"https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003" }
+"https://github.com/gfx-rs/gfx.git#gfx-backend-empty:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003" }

--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -384,6 +384,7 @@ fn replace_sampler_definition_with_texture_and_sampler(
                     ty: DescriptorType::SampledImage,
                     count: 1,
                     stage_flags: ShaderStageFlags::ALL,
+                    immutable_samplers: false,
                 });
             bindings_map.insert(texture_name.clone(), *binding);
         }
@@ -408,6 +409,7 @@ fn replace_sampler_definition_with_texture_and_sampler(
                     ty: DescriptorType::Sampler,
                     count: 1,
                     stage_flags: ShaderStageFlags::ALL,
+                    immutable_samplers: false,
                 });
             bindings_map.insert(String::from(*sampler_name), *binding);
         }
@@ -438,6 +440,7 @@ fn add_locals_to_descriptor_set_layout(
             ty: DescriptorType::UniformBuffer,
             count: 1,
             stage_flags: ShaderStageFlags::VERTEX,
+            immutable_samplers: false,
         }
     );
     bindings_map.insert("Locals".to_owned(), 0);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3312,9 +3312,9 @@ impl<B: hal::Backend> Renderer<B> {
         self.device.disable_depth_write();
         self.device.set_blend(false);
 
-        /*for rect in &target.clears {
+        for rect in &target.clears {
             self.device.clear_target(Some([0.0, 0.0, 0.0, 0.0]), None, Some(*rect));
-        }*/
+        }
 
         // Handle any blits to this texture from child tasks.
         self.handle_blits(&target.blits, render_tasks);


### PR DESCRIPTION
This fixes: https://github.com/szeged/webrender/issues/69, but there is a validation layer warning when running the `boxshadow\box-shadow-large-blur-radius` reftest:
 - WARN: [Validation] Object: 0x172c8d549c8 (Type = 6) | vkCmdClearAttachments() issued on command buffer object 0x172c8d549c8 prior to any Draw Cmds. It is recommended you use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.

Also updated the gfx version to the point where the clear attachments were introduced.
