### PR TITLE
Apply changes made in alternative backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -981,7 +981,7 @@ dependencies = [
  "lyon_geom 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_path 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1011,7 +1011,7 @@ dependencies = [
  "lyon_path 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_path_utils 0.1.0 (git+https://github.com/pcwalton/pathfinder)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ dependencies = [
  "lyon_geom 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_path 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1079,10 +1079,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1190,7 +1190,7 @@ name = "serde"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1203,13 +1203,19 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.58"
+source = "git+https://github.com/servo/serde?branch=deserialize_from_enums7#884e8078a9c74314fa4a5a2e6ce4ac67ab8fa415"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "serde_derive 1.0.58 (git+https://github.com/servo/serde?branch=deserialize_from_enums7)"
 
 [[package]]
 name = "serde_json"
@@ -1312,11 +1318,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.14.2"
+version = "0.13.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1638,7 +1644,7 @@ dependencies = [
  "ipc-channel 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1963,10 +1969,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
 "checksum plane-split 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7079b8485b4f9d9560dee7a69ca8f6ca781f9f284ff9d2bf27255d440b03e4af"
 "checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
-"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
@@ -1982,7 +1988,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95"
 "checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
-"checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
+"checksum serde_derive 1.0.58 (git+https://github.com/servo/serde?branch=deserialize_from_enums7)" = "<none>"
+"checksum serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ac38f51a52a556cd17545798e29536885fb1a3fa63d6399f5ef650f4a7d35901"
 "checksum serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "fc97cccc2959f39984524026d760c08ef0dd5f0f5948c8d31797dbfae458c875"
 "checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
 "checksum servo-fontconfig-sys 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "38b494f03009ee81914b0e7d387ad7c145cafcd69747c2ec89b0e17bb94f303a"
@@ -1996,7 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ debug = true
 panic = "abort"
 
 [replace]
-#"https://github.com/serde-rs/serde#serde_derive:1.0.58" = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums7", feature="deserialize_in_place" }
+"https://github.com/rust-lang/crates.io-index#serde_derive:1.0.58" = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums7", feature="deserialize_in_place" }
 "https://github.com/gfx-rs/gfx.git#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003"}
 "https://github.com/gfx-rs/gfx.git#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003" }
 "https://github.com/gfx-rs/gfx.git#gfx-backend-dx12:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="e2f040d8ff0c903ba38f68aa301d041deb512003" }

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -4,8 +4,8 @@
 
 use api::{ColorU, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
 use debug_font_data;
-use device::{Device, ProgramId, Texture, TextureSlot};
-use device::{PipelineRequirements, ShaderKind, TextureFilter};
+use device::{Device, PipelineRequirements, ProgramId as Program, ShaderKind, Texture, TextureSlot, VAO};
+use device::{VertexDescriptor, TextureFilter, VertexAttribute, VertexAttributeKind, VertexUsageHint};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use hal;
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
@@ -26,6 +26,43 @@ impl Into<TextureSlot> for DebugSampler {
         }
     }
 }
+
+const DESC_FONT: VertexDescriptor = VertexDescriptor {
+    vertex_attributes: &[
+        VertexAttribute {
+            name: "aPosition",
+            count: 2,
+            kind: VertexAttributeKind::F32,
+        },
+        VertexAttribute {
+            name: "aColor",
+            count: 4,
+            kind: VertexAttributeKind::U8Norm,
+        },
+        VertexAttribute {
+            name: "aColorTexCoord",
+            count: 2,
+            kind: VertexAttributeKind::F32,
+        },
+    ],
+    instance_attributes: &[],
+};
+
+const DESC_COLOR: VertexDescriptor = VertexDescriptor {
+    vertex_attributes: &[
+        VertexAttribute {
+            name: "aPosition",
+            count: 2,
+            kind: VertexAttributeKind::F32,
+        },
+        VertexAttribute {
+            name: "aColor",
+            count: 4,
+            kind: VertexAttributeKind::U8Norm,
+        },
+    ],
+    instance_attributes: &[],
+};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -59,48 +96,59 @@ impl DebugColorVertex {
     }
 }
 
+fn create_debug_programs<B: hal::Backend>(device: &mut Device<B>)-> (Program, Program) {
+    let file =
+        File::open(concat!(env!("OUT_DIR"), "/shader_bindings.ron")).expect("Unable to open the file");
+    let mut pipeline_requirements: HashMap<String, PipelineRequirements> =
+        from_reader(file).expect("Failed to load shader_bindings.ron");
+
+    let pipeline_requirement =
+        pipeline_requirements
+            .remove("debug_font")
+            .expect("Pipeline requirements not found for debug_font");
+
+    let font_program =
+        device.create_program(
+                pipeline_requirement,
+            "debug_font",
+            &ShaderKind::DebugFont,
+        );
+
+    let pipeline_requirement_color =
+        pipeline_requirements
+            .remove("debug_color")
+            .expect("Pipeline requirements not found for debug_color");
+
+    let color_program = device
+        .create_program(
+            pipeline_requirement_color,
+        "debug_color",
+        &ShaderKind::DebugColor
+        );
+    (font_program, color_program)
+}
+
 pub struct DebugRenderer {
     font_vertices: Vec<DebugFontVertex>,
     font_indices: Vec<u32>,
-    font_program: ProgramId,
+    font_program: Program,
+    font_vao: VAO,
     font_texture: Texture,
 
     tri_vertices: Vec<DebugColorVertex>,
     tri_indices: Vec<u32>,
+    tri_vao: VAO,
     line_vertices: Vec<DebugColorVertex>,
-    color_program: ProgramId,
+    line_vao: VAO,
+    color_program: Program,
 }
 
 impl DebugRenderer {
     pub fn new<B: hal::Backend>(device: &mut Device<B>) -> Self {
-        let file =
-            File::open(concat!(env!("OUT_DIR"), "/shader_bindings.ron")).expect("Unable to open the file");
-        let mut pipeline_requirements: HashMap<String, PipelineRequirements> =
-            from_reader(file).expect("Failed to load shader_bindings.ron");
-
-        let pipeline_requirement =
-            pipeline_requirements
-                .remove("debug_font")
-                .expect("Pipeline requirements not found for debug_font");
-
-        let font_program =
-            device.create_program(
-                pipeline_requirement,
-                "debug_font",
-                &ShaderKind::DebugFont,
-            );
-
-        let pipeline_requirement_color =
-            pipeline_requirements
-                .remove("debug_color")
-                .expect("Pipeline requirements not found for debug_color");
-
-        let color_program = device
-            .create_program(
-                pipeline_requirement_color,
-                "debug_color",
-                &ShaderKind::DebugColor
-            );
+        let (font_program, color_program) = create_debug_programs(device);
+        let font_vao = device.create_vao(&DESC_FONT);
+        let line_vao = device.create_vao(&DESC_COLOR);
+        let tri_vao = device.create_vao(&DESC_COLOR);
 
         let mut font_texture = device.create_texture(TextureTarget::Array, ImageFormat::R8);
         device.init_texture(
@@ -117,10 +165,13 @@ impl DebugRenderer {
             font_vertices: Vec::new(),
             font_indices: Vec::new(),
             line_vertices: Vec::new(),
+            tri_vao,
             tri_vertices: Vec::new(),
             tri_indices: Vec::new(),
             font_program,
             color_program,
+            font_vao,
+            line_vao,
             font_texture,
         }
     }
@@ -129,6 +180,9 @@ impl DebugRenderer {
         device.delete_texture(self.font_texture);
         device.delete_program(self.font_program);
         device.delete_program(self.color_program);
+        device.delete_vao(self.tri_vao);
+        device.delete_vao(self.line_vao);
+        device.delete_vao(self.font_vao);
     }
 
     pub fn line_height(&self) -> f32 {
@@ -261,30 +315,44 @@ impl DebugRenderer {
 
             // Triangles
             if !self.tri_vertices.is_empty() {
-                device.bind_program(self.color_program);
+                device.bind_program(&self.color_program);
                 device.set_uniforms(&self.color_program, &projection);
-                device.update_indices(self.tri_indices.as_slice());
-                device.update_vertices(&self.tri_vertices);
-                device.draw();
+                device.bind_vao(&self.tri_vao);
+                device.update_vao_indices(&self.tri_vao, &self.tri_indices, VertexUsageHint::Dynamic);
+                device.update_vao_main_vertices(
+                    &self.tri_vao,
+                    &self.tri_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_triangles_u32(0, self.tri_indices.len() as i32);
             }
 
             // Lines
             if !self.line_vertices.is_empty() {
-                device.bind_program(self.color_program);
+                device.bind_program(&self.color_program);
                 device.set_uniforms(&self.color_program, &projection);
-                device.update_vertices(&self.line_vertices);
-                device.draw();
+                device.bind_vao(&self.line_vao);
+                device.update_vao_main_vertices(
+                    &self.line_vao,
+                    &self.line_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_nonindexed_lines(0, self.line_vertices.len() as i32);
             }
 
             // Glyph
             if !self.font_indices.is_empty() {
-                device.bind_program(self.font_program);
+                device.bind_program(&self.font_program);
                 device.set_uniforms(&self.font_program, &projection);
                 device.bind_texture(DebugSampler::Font, &self.font_texture);
-                device.update_indices(self.font_indices.as_slice());
-                device.update_vertices(&self.font_vertices);
-                device.bind_textures();
-                device.draw();
+                device.bind_vao(&self.font_vao);
+                device.update_vao_indices(&self.font_vao, &self.font_indices, VertexUsageHint::Dynamic);
+                device.update_vao_main_vertices(
+                    &self.font_vao,
+                    &self.font_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_triangles_u32(0, self.font_indices.len() as i32);
             }
         }
 

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -262,7 +262,7 @@ impl DebugRenderer {
             // Triangles
             if !self.tri_vertices.is_empty() {
                 device.bind_program(self.color_program);
-                device.set_uniforms(&projection);
+                device.set_uniforms(&self.color_program, &projection);
                 device.update_indices(self.tri_indices.as_slice());
                 device.update_vertices(&self.tri_vertices);
                 device.draw();
@@ -271,7 +271,7 @@ impl DebugRenderer {
             // Lines
             if !self.line_vertices.is_empty() {
                 device.bind_program(self.color_program);
-                device.set_uniforms(&projection);
+                device.set_uniforms(&self.color_program, &projection);
                 device.update_vertices(&self.line_vertices);
                 device.draw();
             }
@@ -279,7 +279,7 @@ impl DebugRenderer {
             // Glyph
             if !self.font_indices.is_empty() {
                 device.bind_program(self.font_program);
-                device.set_uniforms(&projection);
+                device.set_uniforms(&self.font_program, &projection);
                 device.bind_texture(DebugSampler::Font, &self.font_texture);
                 device.update_indices(self.font_indices.as_slice());
                 device.update_vertices(&self.font_vertices);

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -2316,6 +2316,8 @@ impl<B: hal::Backend> Device<B> {
         }
     }
 
+    pub(crate) fn bound_program(&self) -> ProgramId { self.bound_program }
+
     pub fn set_device_pixel_ratio(&mut self, ratio: f32) {
         self.device_pixel_ratio = ratio;
     }
@@ -2447,10 +2449,12 @@ impl<B: hal::Backend> Device<B> {
 
     pub fn set_uniforms(
         &mut self,
+        program: &ProgramId,
         transform: &Transform3D<f32>,
     ) {
         debug_assert!(self.inside_frame);
         assert_ne!(self.bound_program, INVALID_PROGRAM_ID);
+        assert_eq!(*program, self.bound_program);
         let program = self.programs.get_mut(&self.bound_program).expect("Program not found.");
         let desc_set = &self.descriptor_pools[self.next_id].get(&program.shader_kind);
         program.bind_locals(&self.device, desc_set, transform, self.device_pixel_ratio, self.program_mode_id, self.next_id);

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -48,7 +48,7 @@ extern crate cfg_if;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[cfg(any(feature = "gfx", feature = "serde"))]
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 #[macro_use]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3060,7 +3060,8 @@ impl<B: hal::Backend> Renderer<B> {
                 if batch.key.blend_mode == BlendMode::SubpixelWithBgColor {
                     self.device.set_blend_mode_subpixel_with_bg_color_pass1();
                     self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass1 as _);
-                    self.device.set_uniforms(projection);
+                    let program = self.device.bound_program();
+                    self.device.set_uniforms(&program, projection);
                     self.device.bind_textures();
 
                     // When drawing the 2nd and 3rd passes, we know that the VAO, textures etc
@@ -3072,7 +3073,9 @@ impl<B: hal::Backend> Renderer<B> {
 
                     self.device.set_blend_mode_subpixel_with_bg_color_pass2();
                     self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass2 as _);
-                    self.device.set_uniforms(projection);
+                    // In case of gfx we can't avoid re-uploading and re-binding,
+                    // since we have a new pipeline for the new draw.
+                    self.device.set_uniforms(&program, projection);
                     self.device.bind_textures();
 
                     self.device

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3508,7 +3508,7 @@ impl<B: hal::Backend> Renderer<B> {
         let mut index = self.texture_resolver.render_target_pool
             .iter()
             .position(|texture| {
-                //TODO add this upstream
+                //TODO: fix this, our init_texture is handling this case incorrectly.
                 !texture.used_in_frame(frame_id) &&
                 //TODO: re-use a part of a larger target, if available
                 selector == TargetSelector {

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -116,7 +116,7 @@ impl LazilyCompiledShader {
             }
         };
         device.bind_program(program);
-        device.set_uniforms(projection);
+        device.set_uniforms(&program, projection);
     }
 
     fn get<B: hal::Backend>(&mut self, device: &mut Device<B>) -> Result<ProgramId, ShaderError> {

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -115,7 +115,7 @@ impl LazilyCompiledShader {
                 return;
             }
         };
-        device.bind_program(program);
+        device.bind_program(&program);
         device.set_uniforms(&program, projection);
     }
 


### PR DESCRIPTION
These fixes came from https://github.com/szeged/webrender/pull/185, and we can use them on the master branch also:
 - Removed the `gfx` feature dependency from the `serde` crate declaration, because the `serde` feature is sufficient (`serde` feature is also a part of the `gfx` feature).
 - In `renderer.rs`  we had a misleading TODO comment.
 - Changed the visibility of some functions in `device.rs`. Removed the unused `reset_program` call, and replaced some where clauses with the original generic type syntax.
 - Added a `program` param to the `set_uniform` function of Device, this way we do not diverge from the upstream version of it. Also it helped with the DebugRenderer fix.
- Restored the `render` function of the `DebugRenderer` to be more like the upstream version. This can be handy during rebase.
- Changed the `serde_derive` to point to the servo fork again.