### PR TITLE
Move device functionalities in a trait

### DIFF
--- a/direct-composition/src/main_windows.rs
+++ b/direct-composition/src/main_windows.rs
@@ -11,6 +11,7 @@ extern crate winit;
 use direct_composition::DirectComposition;
 use std::sync::mpsc;
 use webrender::api;
+use webrender::Device;
 use winit::os::windows::WindowExt;
 
 fn main() {
@@ -88,7 +89,7 @@ fn direct_composition_from_window(window: &winit::Window) -> DirectComposition {
 
 struct Rectangle {
     visual: direct_composition::AngleVisual,
-    renderer: Option<webrender::Renderer>,
+    renderer: Option<webrender::Renderer<Device>>,
     api: api::RenderApi,
     document_id: api::DocumentId,
     size: api::DeviceUintSize,

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -152,7 +152,7 @@ pub fn main_wrapper<E: Example>(
         DeviceUintSize::new(width, height)
     };
     let notifier = Box::new(Notifier::new(events_loop.create_proxy()));
-    let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), notifier, opts).unwrap();
+    let (mut renderer, sender) = webrender::Renderer::<webrender::Device>::new(gl.clone(), notifier, opts).unwrap();
     let api = sender.create_api();
     let document_id = api.add_document(framebuffer_size, 0);
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -46,7 +46,7 @@ impl RenderNotifier for Notifier {
 struct Window {
     events_loop: winit::EventsLoop, //TODO: share events loop?
     window: glutin::GlWindow,
-    renderer: webrender::Renderer,
+    renderer: webrender::Renderer<webrender::Device>,
     name: &'static str,
     pipeline_id: PipelineId,
     document_id: DocumentId,

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -4,7 +4,7 @@
 
 use api::{ColorU, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
 use debug_font_data;
-use device::{Device, Program, Texture, TextureSlot, VertexDescriptor, VAO};
+use device::{DeviceMethods, TextureSlot, VertexDescriptor};
 use device::{TextureFilter, VertexAttribute, VertexAttributeKind, VertexUsageHint};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
@@ -88,23 +88,23 @@ impl DebugColorVertex {
     }
 }
 
-pub struct DebugRenderer {
+pub struct DebugRenderer<D: DeviceMethods> {
     font_vertices: Vec<DebugFontVertex>,
     font_indices: Vec<u32>,
-    font_program: Program,
-    font_vao: VAO,
+    font_program: D::Program,
+    font_vao: D::VAO,
     font_texture: Texture,
 
     tri_vertices: Vec<DebugColorVertex>,
     tri_indices: Vec<u32>,
-    tri_vao: VAO,
+    tri_vao: D::VAO,
     line_vertices: Vec<DebugColorVertex>,
-    line_vao: VAO,
-    color_program: Program,
+    line_vao: D::VAO,
+    color_program: D::Program,
 }
 
-impl DebugRenderer {
-    pub fn new(device: &mut Device) -> Self {
+impl<D: DeviceMethods> DebugRenderer<D> {
+    pub fn new(device: &mut D) -> Self {
         let font_program = device.create_program("debug_font", "", &DESC_FONT).unwrap();
         device.bind_shader_samplers(&font_program, &[("sColor0", DebugSampler::Font)]);
 
@@ -142,7 +142,7 @@ impl DebugRenderer {
         }
     }
 
-    pub fn deinit(self, device: &mut Device) {
+    pub fn deinit(self, device: &mut D) {
         device.delete_texture(self.font_texture);
         device.delete_program(self.font_program);
         device.delete_program(self.color_program);
@@ -262,7 +262,7 @@ impl DebugRenderer {
 
     pub fn render(
         &mut self,
-        device: &mut Device,
+        device: &mut D,
         viewport_size: Option<DeviceUintSize>,
     ) {
         if let Some(viewport_size) = viewport_size {

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -4,8 +4,8 @@
 
 use api::{ColorU, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
 use debug_font_data;
-use device::{DeviceMethods, TextureSlot, VertexDescriptor};
-use device::{TextureFilter, VertexAttribute, VertexAttributeKind, VertexUsageHint};
+use device::{DeviceMethods, Texture, TextureFilter, TextureSlot, VertexAttribute};
+use device::{VertexAttributeKind, VertexDescriptor, VertexUsageHint};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
 use std::f32;

--- a/webrender/src/device/common.rs
+++ b/webrender/src/device/common.rs
@@ -1,0 +1,275 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api::ImageFormat;
+use internal_types::FastHashMap;
+use shader_source;
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::Read;
+use std::mem;
+use std::ops::Add;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::slice;
+use std::sync::Arc;
+
+
+#[derive(Debug, Copy, Clone, PartialEq, Ord, Eq, PartialOrd)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct FrameId(pub(crate) usize);
+
+impl FrameId {
+    pub fn new(value: usize) -> Self {
+        FrameId(value)
+    }
+}
+
+impl Add<usize> for FrameId {
+    type Output = FrameId;
+
+    fn add(self, other: usize) -> FrameId {
+        FrameId(self.0 + other)
+    }
+}
+
+const SHADER_KIND_VERTEX: &str = "#define WR_VERTEX_SHADER\n";
+const SHADER_KIND_FRAGMENT: &str = "#define WR_FRAGMENT_SHADER\n";
+const SHADER_IMPORT: &str = "#include ";
+
+pub struct TextureSlot(pub usize);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum TextureFilter {
+    Nearest,
+    Linear,
+    Trilinear,
+}
+
+#[derive(Debug)]
+pub enum VertexAttributeKind {
+    F32,
+    #[cfg(feature = "debug_renderer")]
+    U8Norm,
+    U16Norm,
+    I32,
+    U16,
+}
+
+#[derive(Debug)]
+pub struct VertexAttribute {
+    pub name: &'static str,
+    pub count: u32,
+    pub kind: VertexAttributeKind,
+}
+
+#[derive(Debug)]
+pub struct VertexDescriptor {
+    pub vertex_attributes: &'static [VertexAttribute],
+    pub instance_attributes: &'static [VertexAttribute],
+}
+
+/// Method of uploading texel data from CPU to GPU.
+#[derive(Debug, Clone)]
+pub enum UploadMethod {
+    /// Just call `glTexSubImage` directly with the CPU data pointer
+    Immediate,
+    /// Accumulate the changes in PBO first before transferring to a texture.
+    PixelBuffer(VertexUsageHint),
+}
+
+/// Plain old data that can be used to initialize a texture.
+pub unsafe trait Texel: Copy {}
+unsafe impl Texel for u8 {}
+unsafe impl Texel for f32 {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ReadPixelsFormat {
+    Standard(ImageFormat),
+    Rgba8,
+}
+
+// Get a shader string by name, from the built in resources or
+// an override path, if supplied.
+fn get_shader_source(shader_name: &str, base_path: &Option<PathBuf>) -> Option<String> {
+    if let Some(ref base) = *base_path {
+        let shader_path = base.join(&format!("{}.glsl", shader_name));
+        if shader_path.exists() {
+            let mut source = String::new();
+            File::open(&shader_path)
+                .unwrap()
+                .read_to_string(&mut source)
+                .unwrap();
+            return Some(source);
+        }
+    }
+
+    shader_source::SHADERS
+        .get(shader_name)
+        .map(|s| s.to_string())
+}
+
+// Parse a shader string for imports. Imports are recursively processed, and
+// prepended to the list of outputs.
+fn parse_shader_source(source: String, base_path: &Option<PathBuf>, output: &mut String) {
+    for line in source.lines() {
+        if line.starts_with(SHADER_IMPORT) {
+            let imports = line[SHADER_IMPORT.len() ..].split(',');
+
+            // For each import, get the source, and recurse.
+            for import in imports {
+                if let Some(include) = get_shader_source(import, base_path) {
+                    parse_shader_source(include, base_path, output);
+                }
+            }
+        } else {
+            output.push_str(line);
+            output.push_str("\n");
+        }
+    }
+}
+
+pub fn build_shader_strings(
+    gl_version_string: &str,
+    features: &str,
+    base_filename: &str,
+    override_path: &Option<PathBuf>,
+) -> (String, String) {
+    // Construct a list of strings to be passed to the shader compiler.
+    let mut vs_source = String::new();
+    let mut fs_source = String::new();
+
+    // GLSL requires that the version number comes first.
+    vs_source.push_str(gl_version_string);
+    fs_source.push_str(gl_version_string);
+
+    // Insert the shader name to make debugging easier.
+    let name_string = format!("// {}\n", base_filename);
+    vs_source.push_str(&name_string);
+    fs_source.push_str(&name_string);
+
+    // Define a constant depending on whether we are compiling VS or FS.
+    vs_source.push_str(SHADER_KIND_VERTEX);
+    fs_source.push_str(SHADER_KIND_FRAGMENT);
+
+    // Add any defines that were passed by the caller.
+    vs_source.push_str(features);
+    fs_source.push_str(features);
+
+    // Parse the main .glsl file, including any imports
+    // and append them to the list of sources.
+    let mut shared_result = String::new();
+    if let Some(shared_source) = get_shader_source(base_filename, override_path) {
+        parse_shader_source(shared_source, override_path, &mut shared_result);
+    }
+
+    vs_source.push_str(&shared_result);
+    fs_source.push_str(&shared_result);
+
+    (vs_source, fs_source)
+}
+
+pub trait FileWatcherHandler: Send {
+    fn file_changed(&self, path: PathBuf);
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serialize_program", derive(Deserialize, Serialize))]
+pub struct ProgramSources {
+    renderer_name: String,
+    pub(crate) vs_source: String,
+    pub(crate) fs_source: String,
+}
+
+impl ProgramSources {
+    pub(crate) fn new(renderer_name: String, vs_source: String, fs_source: String) -> Self {
+        ProgramSources {
+            renderer_name,
+            vs_source,
+            fs_source,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serialize_program", derive(Deserialize, Serialize))]
+pub struct ProgramBinary {
+    pub(crate) binary: Vec<u8>,
+    pub(crate) format: u32,//gl::GLenum,
+    #[cfg(feature = "serialize_program")]
+    pub(crate) sources: ProgramSources,
+}
+
+impl ProgramBinary {
+    #[allow(unused_variables)]
+    pub(crate) fn new(binary: Vec<u8>,
+           format: u32,//gl::GLenum,
+           sources: &ProgramSources) -> Self {
+        ProgramBinary {
+            binary,
+            format,
+            #[cfg(feature = "serialize_program")]
+            sources: sources.clone(),
+        }
+    }
+}
+
+/// The interfaces that an application can implement to handle ProgramCache update
+pub trait ProgramCacheObserver {
+    fn notify_binary_added(&self, program_binary: &Arc<ProgramBinary>);
+    fn notify_program_binary_failed(&self, program_binary: &Arc<ProgramBinary>);
+}
+
+pub struct ProgramCache {
+    pub(crate) binaries: RefCell<FastHashMap<ProgramSources, Arc<ProgramBinary>>>,
+
+    /// Optional trait object that allows the client
+    /// application to handle ProgramCache updating
+    /// application to handle ProgramCache updating
+    pub(crate) program_cache_handler: Option<Box<ProgramCacheObserver>>,
+}
+
+impl ProgramCache {
+    pub fn new(program_cache_observer: Option<Box<ProgramCacheObserver>>) -> Rc<Self> {
+        Rc::new(
+            ProgramCache {
+                binaries: RefCell::new(FastHashMap::default()),
+                program_cache_handler: program_cache_observer,
+            }
+        )
+    }
+    /// Load ProgramBinary to ProgramCache.
+    /// The function is typically used to load ProgramBinary from disk.
+    #[cfg(feature = "serialize_program")]
+    pub fn load_program_binary(&self, program_binary: Arc<ProgramBinary>) {
+        let sources = program_binary.sources.clone();
+        self.binaries.borrow_mut().insert(sources, program_binary);
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum VertexUsageHint {
+    Static,
+    Dynamic,
+    Stream,
+}
+
+#[cfg(feature = "debug_renderer")]
+pub struct Capabilities {
+    pub supports_multisampling: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum ShaderError {
+    Compilation(String, String), // name, error message
+    Link(String, String),        // name, error message
+}
+
+pub(crate) fn texels_to_u8_slice<T: Texel>(texels: &[T]) -> &[u8] {
+    unsafe {
+        slice::from_raw_parts(texels.as_ptr() as *const u8, texels.len() * mem::size_of::<T>())
+    }
+}

--- a/webrender/src/device/device_trait.rs
+++ b/webrender/src/device/device_trait.rs
@@ -1,0 +1,315 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api::{ColorF, DeviceIntRect, DeviceUintSize, DeviceUintRect, ImageFormat, TextureTarget};
+#[cfg(any(feature = "debug_renderer", feature = "capture"))]
+use api::{ImageDescriptor};
+use device::gl::{DeviceInit, DepthFunction, Stream, TextureUploader, VBO, Texture, ExternalTexture};
+use device::common::{FileWatcherHandler, FrameId, ProgramCache, ReadPixelsFormat, ShaderError,
+                     Texel, TextureFilter, TextureSlot, UploadMethod, VertexDescriptor, VertexUsageHint};
+#[cfg(feature = "debug_renderer")]
+use device::common::Capabilities;
+use euclid::Transform3D;
+use internal_types::RenderTargetInfo;
+use std::convert::From;
+use std::hash::Hash;
+use std::fmt::Debug;
+use std::marker::Sized;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+pub trait DeviceMethods
+    where Self: Sized,
+{
+    type CustomVAO;
+    type FBOId: PartialEq + Eq + Hash + Debug + Copy + Clone;
+    type PBO;
+    type Program;
+    type RBOId: PartialEq + Eq + Hash + Debug + Copy + Clone;
+    type TextureId: PartialEq + Eq + Hash + Debug + Copy + Clone + From<u32>;
+    type VAO;
+    //type ExternalTexture;
+    //type Texture;
+
+    fn new(
+        init: DeviceInit,
+        resource_override_path: Option<PathBuf>,
+        upload_method: UploadMethod,
+        _file_changed_handler: Box<FileWatcherHandler>,
+        cached_programs: Option<Rc<ProgramCache>>,
+    ) -> Self;
+
+    fn renderer(&self) -> String;
+
+    fn version(&self) -> String;
+
+    fn get_context(&self) -> &DeviceInit;
+
+    fn set_device_pixel_ratio(&mut self, ratio: f32);
+
+    fn update_program_cache(&mut self, cached_programs: Rc<ProgramCache>);
+
+    fn max_texture_size(&self) -> u32;
+
+    #[cfg(feature = "debug_renderer")]
+    fn get_capabilities(&self) -> &Capabilities;
+
+    fn reset_state(&mut self);
+
+    fn begin_frame(&mut self) -> FrameId;
+
+    fn bind_texture<S>(&mut self, sampler: S, texture: &/*Self::*/Texture)
+        where
+            S: Into<TextureSlot>;
+
+    fn bind_external_texture<S>(&mut self, sampler: S, external_texture: &/*Self::*/ExternalTexture)
+        where
+            S: Into<TextureSlot>;
+
+    fn bind_read_target_impl(&mut self, fbo_id: Self::FBOId);
+
+    fn bind_read_target(&mut self, texture_and_layer: Option<(&/*Self::*/Texture, i32)>);
+
+    fn bind_draw_target(
+        &mut self,
+        texture_and_layer: Option<(&/*Self::*/Texture, i32)>,
+        dimensions: Option<DeviceUintSize>,
+    );
+
+    fn create_fbo_for_external_texture(&mut self, texture_id: u32) -> Self::FBOId;
+
+    fn delete_fbo(&mut self, fbo: Self::FBOId);
+
+    fn bind_external_draw_target(&mut self, fbo_id: Self::FBOId);
+
+    fn bind_program(&mut self, program: &Self::Program);
+
+    fn create_texture(
+        &mut self,
+        target: TextureTarget,
+        format: ImageFormat,
+    ) -> /*Self::*/Texture;
+
+    /// Resizes a texture with enabled render target views,
+    /// preserves the data by blitting the old texture contents over.
+    fn resize_renderable_texture(
+        &mut self,
+        texture: &mut /*Self::*/Texture,
+        new_size: DeviceUintSize,
+    );
+
+    fn init_texture<T: Texel>(
+        &mut self,
+        texture: &mut /*Self::*/Texture,
+        width: u32,
+        height: u32,
+        filter: TextureFilter,
+        render_target: Option<RenderTargetInfo>,
+        layer_count: i32,
+        pixels: Option<&[T]>,
+    );
+
+    fn blit_render_target(&mut self, src_rect: DeviceIntRect, dest_rect: DeviceIntRect);
+
+    fn free_texture_storage(&mut self, texture: &mut /*Self::*/Texture);
+
+    fn delete_texture(&mut self, texture: /*Self::*/Texture);
+
+    #[cfg(feature = "replay")]
+    fn delete_external_texture(&mut self, external: /*Self::*/ExternalTexture);
+
+    fn delete_program(&mut self, program: Self::Program);
+
+    fn create_program(
+        &mut self,
+        base_filename: &str,
+        features: &str,
+        descriptor: &VertexDescriptor,
+    ) -> Result<Self::Program, ShaderError>;
+
+    fn bind_shader_samplers<S>(&mut self, program: &Self::Program, bindings: &[(&'static str, S)])
+        where
+            S: Into<TextureSlot> + Copy;
+
+    fn set_uniforms(
+        &self,
+        program: &Self::Program,
+        transform: &Transform3D<f32>,
+    );
+
+    fn switch_mode(&self, mode: i32);
+
+    fn create_pbo(&mut self) -> Self::PBO;
+
+    fn delete_pbo(&mut self, pbo: Self::PBO);
+
+    fn upload_texture<'a, T>(
+        &'a mut self,
+        texture: &'a /*Self::*/Texture,
+        pbo: &Self::PBO,
+        upload_count: usize,
+    ) -> TextureUploader<'a, T>;
+
+    #[cfg(any(feature = "debug_renderer", feature = "capture"))]
+    fn read_pixels(&mut self, img_desc: &ImageDescriptor) -> Vec<u8>;
+
+    /// Read rectangle of pixels into the specified output slice.
+    fn read_pixels_into(
+        &mut self,
+        rect: DeviceUintRect,
+        format: ReadPixelsFormat,
+        output: &mut [u8],
+    );
+
+    #[cfg(any(feature = "debug_renderer", feature="capture"))]
+    fn attach_read_texture_external(
+        &mut self,
+        texture_id: Self::TextureId,
+        target: TextureTarget,
+        layer_id: i32,
+    );
+
+    #[cfg(any(feature = "debug_renderer", feature="capture"))]
+    fn attach_read_texture(
+        &mut self,
+        texture: &/*Self::*/Texture,
+        layer_id: i32,
+    );
+
+    fn bind_vao(&mut self, vao: &Self::VAO);
+
+    fn bind_custom_vao(&mut self, vao: &Self::CustomVAO);
+
+    fn create_custom_vao(
+        &mut self,
+        streams: &[Stream],
+    ) -> Self::CustomVAO;
+
+    fn delete_custom_vao(&mut self, vao: Self::CustomVAO);
+
+    fn create_vbo<V>(&mut self) -> VBO<V>;
+
+    fn delete_vbo<V>(&mut self, vbo: VBO<V>);
+
+    fn create_vao(&mut self, descriptor: &VertexDescriptor) -> Self::VAO;
+
+    fn delete_vao(&mut self, vao: Self::VAO);
+
+    fn allocate_vbo<V>(
+        &mut self,
+        vbo: &mut VBO<V>,
+        count: usize,
+        usage_hint: VertexUsageHint,
+    );
+
+    fn fill_vbo<V>(
+        &mut self,
+        vbo: &VBO<V>,
+        data: &[V],
+        offset: usize,
+    );
+
+    fn create_vao_with_new_instances(
+        &mut self,
+        descriptor: &VertexDescriptor,
+        base_vao: &Self::VAO,
+    ) -> Self::VAO;
+
+    fn update_vao_main_vertices<V>(
+        &mut self,
+        vao: &Self::VAO,
+        vertices: &[V],
+        usage_hint: VertexUsageHint,
+    );
+
+    fn update_vao_instances<V>(
+        &mut self,
+        vao: &Self::VAO,
+        instances: &[V],
+        usage_hint: VertexUsageHint,
+    );
+
+    fn update_vao_indices<I>(
+        &mut self,
+        vao: &Self::VAO,
+        indices: &[I],
+        usage_hint: VertexUsageHint,
+    );
+
+    fn draw_triangles_u16(&mut self, first_vertex: i32, index_count: i32);
+
+    #[cfg(feature = "debug_renderer")]
+    fn draw_triangles_u32(&mut self, first_vertex: i32, index_count: i32);
+
+    fn draw_nonindexed_points(&mut self, first_vertex: i32, vertex_count: i32);
+
+    #[cfg(feature = "debug_renderer")]
+    fn draw_nonindexed_lines(&mut self, first_vertex: i32, vertex_count: i32);
+
+    fn draw_indexed_triangles_instanced_u16(
+        &mut self,
+        index_count: i32,
+        instance_count: i32,
+    );
+
+    fn end_frame(&mut self);
+
+    fn clear_target(
+        &self,
+        color: Option<[f32; 4]>,
+        depth: Option<f32>,
+        rect: Option<DeviceIntRect>,
+    );
+
+    fn enable_depth(&self);
+
+    fn disable_depth(&self);
+
+    fn set_depth_func(&self, depth_func: DepthFunction);
+
+    fn enable_depth_write(&self);
+
+    fn disable_depth_write(&self);
+
+    fn disable_stencil(&self);
+
+    fn set_scissor_rect(&self, rect: DeviceIntRect);
+
+    fn enable_scissor(&self);
+
+    fn disable_scissor(&self);
+
+    fn set_blend(&self, enable: bool);
+
+    fn set_blend_mode_alpha(&self);
+
+    fn set_blend_mode_premultiplied_alpha(&self);
+
+    fn set_blend_mode_premultiplied_dest_out(&self);
+
+    fn set_blend_mode_multiply(&self);
+
+    fn set_blend_mode_max(&self);
+
+    #[cfg(feature = "debug_renderer")]
+    fn set_blend_mode_min(&self);
+
+    fn set_blend_mode_subpixel_pass0(&self);
+
+    fn set_blend_mode_subpixel_pass1(&self);
+
+    fn set_blend_mode_subpixel_with_bg_color_pass0(&self);
+
+    fn set_blend_mode_subpixel_with_bg_color_pass1(&self);
+
+    fn set_blend_mode_subpixel_with_bg_color_pass2(&self);
+
+    fn set_blend_mode_subpixel_constant_text_color(&self, color: ColorF);
+
+    fn set_blend_mode_subpixel_dual_source(&self);
+
+    fn supports_extension(&self, extension: &str) -> bool;
+
+    fn echo_driver_messages(&self);
+}

--- a/webrender/src/device/device_trait.rs
+++ b/webrender/src/device/device_trait.rs
@@ -4,17 +4,17 @@
 
 use api::{ColorF, DeviceIntRect, DeviceUintSize, DeviceUintRect, ImageFormat, TextureTarget};
 #[cfg(any(feature = "debug_renderer", feature = "capture"))]
-use api::{ImageDescriptor};
-use device::gl::{DeviceInit, DepthFunction, Stream, TextureUploader, VBO, Texture, ExternalTexture};
-use device::common::{FileWatcherHandler, FrameId, ProgramCache, ReadPixelsFormat, ShaderError,
-                     Texel, TextureFilter, TextureSlot, UploadMethod, VertexDescriptor, VertexUsageHint};
+use api::ImageDescriptor;
+#[cfg(any(feature = "debug_renderer", feature="capture"))]
+use device::gl::IdType;
+use device::gl::{DeviceInit, DepthFunction, Stream, TextureUploader, VBO};
+use device::common::{CustomVAO, ExternalTexture, FBOId, FileWatcherHandler, FrameId, PBO};
+use device::common::{ProgramCache, ReadPixelsFormat, ShaderError, Texel, Texture, TextureFilter};
+use device::common::{TextureSlot, UploadMethod, VertexDescriptor, VertexUsageHint};
 #[cfg(feature = "debug_renderer")]
 use device::common::Capabilities;
 use euclid::Transform3D;
 use internal_types::RenderTargetInfo;
-use std::convert::From;
-use std::hash::Hash;
-use std::fmt::Debug;
 use std::marker::Sized;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -22,21 +22,14 @@ use std::rc::Rc;
 pub trait DeviceMethods
     where Self: Sized,
 {
-    type CustomVAO;
-    type FBOId: PartialEq + Eq + Hash + Debug + Copy + Clone;
-    type PBO;
     type Program;
-    type RBOId: PartialEq + Eq + Hash + Debug + Copy + Clone;
-    type TextureId: PartialEq + Eq + Hash + Debug + Copy + Clone + From<u32>;
     type VAO;
-    //type ExternalTexture;
-    //type Texture;
 
     fn new(
         init: DeviceInit,
         resource_override_path: Option<PathBuf>,
         upload_method: UploadMethod,
-        _file_changed_handler: Box<FileWatcherHandler>,
+        file_changed_handler: Box<FileWatcherHandler>,
         cached_programs: Option<Rc<ProgramCache>>,
     ) -> Self;
 
@@ -59,29 +52,29 @@ pub trait DeviceMethods
 
     fn begin_frame(&mut self) -> FrameId;
 
-    fn bind_texture<S>(&mut self, sampler: S, texture: &/*Self::*/Texture)
+    fn bind_texture<S>(&mut self, sampler: S, texture: &Texture)
         where
             S: Into<TextureSlot>;
 
-    fn bind_external_texture<S>(&mut self, sampler: S, external_texture: &/*Self::*/ExternalTexture)
+    fn bind_external_texture<S>(&mut self, sampler: S, external_texture: &ExternalTexture)
         where
             S: Into<TextureSlot>;
 
-    fn bind_read_target_impl(&mut self, fbo_id: Self::FBOId);
+    fn bind_read_target_impl(&mut self, fbo_id: FBOId);
 
-    fn bind_read_target(&mut self, texture_and_layer: Option<(&/*Self::*/Texture, i32)>);
+    fn bind_read_target(&mut self, texture_and_layer: Option<(&Texture, i32)>);
 
     fn bind_draw_target(
         &mut self,
-        texture_and_layer: Option<(&/*Self::*/Texture, i32)>,
+        texture_and_layer: Option<(&Texture, i32)>,
         dimensions: Option<DeviceUintSize>,
     );
 
-    fn create_fbo_for_external_texture(&mut self, texture_id: u32) -> Self::FBOId;
+    fn create_fbo_for_external_texture(&mut self, texture_id: u32) -> FBOId;
 
-    fn delete_fbo(&mut self, fbo: Self::FBOId);
+    fn delete_fbo(&mut self, fbo: FBOId);
 
-    fn bind_external_draw_target(&mut self, fbo_id: Self::FBOId);
+    fn bind_external_draw_target(&mut self, fbo_id: FBOId);
 
     fn bind_program(&mut self, program: &Self::Program);
 
@@ -89,19 +82,19 @@ pub trait DeviceMethods
         &mut self,
         target: TextureTarget,
         format: ImageFormat,
-    ) -> /*Self::*/Texture;
+    ) -> Texture;
 
     /// Resizes a texture with enabled render target views,
     /// preserves the data by blitting the old texture contents over.
     fn resize_renderable_texture(
         &mut self,
-        texture: &mut /*Self::*/Texture,
+        texture: &mut Texture,
         new_size: DeviceUintSize,
     );
 
     fn init_texture<T: Texel>(
         &mut self,
-        texture: &mut /*Self::*/Texture,
+        texture: &mut Texture,
         width: u32,
         height: u32,
         filter: TextureFilter,
@@ -112,12 +105,12 @@ pub trait DeviceMethods
 
     fn blit_render_target(&mut self, src_rect: DeviceIntRect, dest_rect: DeviceIntRect);
 
-    fn free_texture_storage(&mut self, texture: &mut /*Self::*/Texture);
+    fn free_texture_storage(&mut self, texture: &mut Texture);
 
-    fn delete_texture(&mut self, texture: /*Self::*/Texture);
+    fn delete_texture(&mut self, texture: Texture);
 
     #[cfg(feature = "replay")]
-    fn delete_external_texture(&mut self, external: /*Self::*/ExternalTexture);
+    fn delete_external_texture(&mut self, external: ExternalTexture);
 
     fn delete_program(&mut self, program: Self::Program);
 
@@ -140,14 +133,14 @@ pub trait DeviceMethods
 
     fn switch_mode(&self, mode: i32);
 
-    fn create_pbo(&mut self) -> Self::PBO;
+    fn create_pbo(&mut self) -> PBO;
 
-    fn delete_pbo(&mut self, pbo: Self::PBO);
+    fn delete_pbo(&mut self, pbo: PBO);
 
     fn upload_texture<'a, T>(
         &'a mut self,
-        texture: &'a /*Self::*/Texture,
-        pbo: &Self::PBO,
+        texture: &'a Texture,
+        pbo: &PBO,
         upload_count: usize,
     ) -> TextureUploader<'a, T>;
 
@@ -165,7 +158,7 @@ pub trait DeviceMethods
     #[cfg(any(feature = "debug_renderer", feature="capture"))]
     fn attach_read_texture_external(
         &mut self,
-        texture_id: Self::TextureId,
+        texture_id: IdType,
         target: TextureTarget,
         layer_id: i32,
     );
@@ -173,20 +166,20 @@ pub trait DeviceMethods
     #[cfg(any(feature = "debug_renderer", feature="capture"))]
     fn attach_read_texture(
         &mut self,
-        texture: &/*Self::*/Texture,
+        texture: &Texture,
         layer_id: i32,
     );
 
     fn bind_vao(&mut self, vao: &Self::VAO);
 
-    fn bind_custom_vao(&mut self, vao: &Self::CustomVAO);
+    fn bind_custom_vao(&mut self, vao: &CustomVAO);
 
     fn create_custom_vao(
         &mut self,
         streams: &[Stream],
-    ) -> Self::CustomVAO;
+    ) -> CustomVAO;
 
-    fn delete_custom_vao(&mut self, vao: Self::CustomVAO);
+    fn delete_custom_vao(&mut self, vao: CustomVAO);
 
     fn create_vbo<V>(&mut self) -> VBO<V>;
 

--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -468,72 +468,6 @@ pub struct Device {
 }
 
 impl Device {
-    /*fn new(
-        gl: Rc<gl::Gl>,
-        resource_override_path: Option<PathBuf>,
-        upload_method: UploadMethod,
-        _file_changed_handler: Box<FileWatcherHandler>,
-        cached_programs: Option<Rc<ProgramCache>>,
-    ) -> GlDevice {
-        let mut max_texture_size = [0];
-        unsafe {
-            gl.get_integer_v(gl::MAX_TEXTURE_SIZE, &mut max_texture_size);
-        }
-        let max_texture_size = max_texture_size[0] as u32;
-        let renderer_name = gl.get_string(gl::RENDERER);
-
-        let mut extension_count = [0];
-        unsafe {
-            gl.get_integer_v(gl::NUM_EXTENSIONS, &mut extension_count);
-        }
-        let extension_count = extension_count[0] as gl::GLuint;
-        let mut extensions = Vec::new();
-        for i in 0 .. extension_count {
-            extensions.push(gl.get_string_i(gl::EXTENSIONS, i));
-        }
-
-        let supports_bgra = supports_extension(&extensions, "GL_EXT_texture_format_BGRA8888");
-        let bgra_format = match gl.get_type() {
-            gl::GlType::Gl => GL_FORMAT_BGRA_GL,
-            gl::GlType::Gles => if supports_bgra {
-                GL_FORMAT_BGRA_GLES
-            } else {
-                GL_FORMAT_RGBA
-            }
-        };
-
-        GlDevice {
-            gl,
-            resource_override_path,
-            // This is initialized to 1 by default, but it is reset
-            // at the beginning of each frame in `Renderer::bind_frame_data`.
-            device_pixel_ratio: 1.0,
-            upload_method,
-            inside_frame: false,
-
-            #[cfg(feature = "debug_renderer")]
-            capabilities: Capabilities {
-                supports_multisampling: false, //TODO
-            },
-
-            bgra_format,
-
-            bound_textures: [0; 16],
-            bound_program: 0,
-            bound_vao: 0,
-            bound_read_fbo: FBOId(0),
-            bound_draw_fbo: FBOId(0),
-            program_mode_id: UniformLocation::INVALID,
-            default_read_fbo: 0,
-            default_draw_fbo: 0,
-
-            max_texture_size,
-            renderer_name,
-            cached_programs,
-            frame_id: FrameId(0),
-            extensions,
-        }
-    }*/
 
     fn gl(&self) -> &gl::Gl {
         &*self.gl
@@ -830,30 +764,6 @@ impl Device {
                 );
             }
         }
-    }
-
-    #[cfg(feature = "debug_renderer")]
-    pub fn get_uniform_location(&self, program: &Program, name: &str) -> UniformLocation {
-        UniformLocation(self.gl.get_uniform_location(program.id, name))
-    }
-
-    /// Get texels of a texture into the specified output slice.
-    #[cfg(feature = "debug_renderer")]
-    pub fn get_tex_image_into(
-        &mut self,
-        texture: &Texture,
-        format: ImageFormat,
-        output: &mut [u8],
-    ) {
-        self.bind_texture(DEFAULT_TEXTURE, texture);
-        let desc = self.gl_describe_format(format);
-        self.gl.get_tex_image_into_buffer(
-            texture.target,
-            0,
-            desc.external,
-            desc.pixel_type,
-            output,
-        );
     }
 
     /// Attaches the provided texture to the current Read FBO binding.

--- a/webrender/src/device/mod.rs
+++ b/webrender/src/device/mod.rs
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod common;
+mod device_trait;
+mod gl;
+mod shader_source {
+    include!(concat!(env!("OUT_DIR"), "/shaders.rs"));
+}
+
+pub use self::common::*;
+pub use self::device_trait::DeviceMethods;
+pub use self::gl::*;

--- a/webrender/src/gpu_glyph_renderer.rs
+++ b/webrender/src/gpu_glyph_renderer.rs
@@ -7,7 +7,7 @@
 use api::{DeviceIntPoint, DeviceIntRect, DeviceUintSize, FontRenderMode};
 use api::{ImageFormat, TextureTarget};
 use debug_colors;
-use device::{Device, Texture, TextureFilter, VAO};
+use device::{DeviceMethods, Texture, TextureFilter};
 use euclid::{Point2D, Size2D, Transform3D, TypedVector2D, Vector2D};
 use internal_types::RenderTargetInfo;
 use pathfinder_gfx_utils::ShelfBinPacker;
@@ -31,19 +31,19 @@ const GPU_TAG_GLYPH_COVER: GpuProfileTag = GpuProfileTag {
     color: debug_colors::LIGHTSTEELBLUE,
 };
 
-pub struct GpuGlyphRenderer {
+pub struct GpuGlyphRenderer<D: DeviceMethods> {
     pub area_lut_texture: Texture,
-    pub vector_stencil_vao: VAO,
-    pub vector_cover_vao: VAO,
+    pub vector_stencil_vao: D::VAO,
+    pub vector_cover_vao: D::VAO,
 
     // These are Pathfinder shaders, used for rendering vector graphics.
-    vector_stencil: LazilyCompiledShader,
-    vector_cover: LazilyCompiledShader,
+    vector_stencil: LazilyCompiledShader<D>,
+    vector_cover: LazilyCompiledShader<D>,
 }
 
-impl GpuGlyphRenderer {
-    pub fn new(device: &mut Device, prim_vao: &VAO, precache_shaders: bool)
-               -> Result<GpuGlyphRenderer, RendererError> {
+impl<D: DeviceMethods> GpuGlyphRenderer<D> {
+    pub fn new(device: &mut D, prim_vao: &D::VAO, precache_shaders: bool)
+               -> Result<GpuGlyphRenderer<D>, RendererError> {
         // Make sure the area LUT is uncompressed grayscale TGA, 8bpp.
         debug_assert!(AREA_LUT_TGA_BYTES[2] == 3);
         debug_assert!(AREA_LUT_TGA_BYTES[16] == 8);
@@ -94,7 +94,7 @@ impl GpuGlyphRenderer {
     }
 }
 
-impl Renderer {
+impl<D: DeviceMethods> Renderer<D> {
     /// Renders glyphs using the vector graphics shaders (Pathfinder).
     pub fn stencil_glyphs(&mut self,
                           glyphs: &[GlyphJob],

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -180,7 +180,7 @@ extern crate png;
 pub extern crate webrender_api;
 
 #[doc(hidden)]
-pub use device::{build_shader_strings, ReadPixelsFormat, UploadMethod, VertexUsageHint};
+pub use device::{build_shader_strings, DeviceMethods, Device, ReadPixelsFormat, UploadMethod, VertexUsageHint};
 pub use device::{ProgramBinary, ProgramCache, ProgramCacheObserver, ProgramSources};
 pub use renderer::{AsyncPropertySampler, CpuProfile, DebugFlags, OutputImageHandler, RendererKind};
 pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource, GpuProfile};

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -20,14 +20,11 @@ use batch::{BatchKind, BatchTextures, BrushBatchKind};
 #[cfg(any(feature = "capture", feature = "replay"))]
 use capture::{CaptureConfig, ExternalCaptureImage, PlainExternalImage};
 use debug_colors;
-use device::{DepthFunction, Device, FrameId, Program, UploadMethod, Texture, PBO};
-use device::{ExternalTexture, FBOId, TextureSlot};
-use device::{FileWatcherHandler, ShaderError, TextureFilter,
-             VertexUsageHint, VAO, VBO, CustomVAO};
-use device::{ProgramCache, ReadPixelsFormat};
+use device::{DeviceInit, DepthFunction, FileWatcherHandler, FrameId};
+use device::{ProgramCache, ReadPixelsFormat, ShaderError, TextureFilter};
+use device::{TextureMethods, TextureSlot, UploadMethod, VertexUsageHint, VBO};
 use euclid::{rect, Transform3D};
 use frame_builder::FrameBuilderConfig;
-use gleam::gl;
 use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
 #[cfg(feature = "pathfinder")]
@@ -53,6 +50,7 @@ use std::cmp;
 use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 use std::f32;
+use std::marker::PhantomData;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -696,12 +694,14 @@ impl CpuProfile {
 }
 
 #[cfg(not(feature = "pathfinder"))]
-pub struct GpuGlyphRenderer;
+pub struct GpuGlyphRenderer<D: DeviceMethods> {
+    phantom: PhantomData<D>,
+}
 
 #[cfg(not(feature = "pathfinder"))]
-impl GpuGlyphRenderer {
-    fn new(_: &mut Device, _: &VAO, _: bool) -> Result<GpuGlyphRenderer, RendererError> {
-        Ok(GpuGlyphRenderer)
+impl<D: DeviceMethods> GpuGlyphRenderer<D> {
+    fn new(_: &mut D, _: &D::VAO, _: bool) -> Result<GpuGlyphRenderer<D>, RendererError> {
+        Ok(GpuGlyphRenderer {phantom: PhantomData})
     }
 }
 
@@ -714,7 +714,7 @@ struct ActiveTexture {
     is_shared: bool,
 }
 
-struct SourceTextureResolver {
+struct SourceTextureResolver<D: DeviceMethods> {
     /// A vector for fast resolves of texture cache IDs to
     /// native texture IDs. This maps to a free-list managed
     /// by the backend thread / texture cache. We free the
@@ -746,10 +746,11 @@ struct SourceTextureResolver {
 
     /// General pool of render targets.
     render_target_pool: Vec<Texture>,
+    phantom: PhantomData<D>,
 }
 
-impl SourceTextureResolver {
-    fn new(device: &mut Device) -> SourceTextureResolver {
+impl<D: DeviceMethods> SourceTextureResolver<D> {
+    fn new(device: &mut D) -> SourceTextureResolver<D> {
         let mut dummy_cache_texture = device
             .create_texture(TextureTarget::Array, ImageFormat::BGRA8);
         device.init_texture::<u8>(
@@ -771,10 +772,11 @@ impl SourceTextureResolver {
             shared_alpha_texture: None,
             saved_textures: Vec::default(),
             render_target_pool: Vec::new(),
+            phantom: PhantomData,
         }
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         device.delete_texture(self.dummy_cache_texture);
 
         for texture in self.cache_texture_map {
@@ -839,7 +841,7 @@ impl SourceTextureResolver {
     }
 
     // Bind a source texture to the device.
-    fn bind(&self, texture_id: &SourceTexture, sampler: TextureSampler, device: &mut Device) {
+    fn bind(&self, texture_id: &SourceTexture, sampler: TextureSampler, device: &mut D) {
         match *texture_id {
             SourceTexture::Invalid => {}
             SourceTexture::CacheA8 => {
@@ -930,12 +932,12 @@ impl CacheRow {
 
 /// The bus over which CPU and GPU versions of the cache
 /// get synchronized.
-enum CacheBus {
+enum CacheBus<D: DeviceMethods> {
     /// PBO-based updates, currently operate on a row granularity.
     /// Therefore, are subject to fragmentation issues.
     PixelBuffer {
         /// PBO used for transfers.
-        buffer: PBO,
+        buffer: D::PBO,
         /// Meta-data about the cached rows.
         rows: Vec<CacheRow>,
         /// Mirrored block data on CPU.
@@ -945,9 +947,9 @@ enum CacheBus {
     /// of points into the GPU texture, each carrying a `GpuBlockData`.
     Scatter {
         /// Special program to run the scattered update.
-        program: Program,
+        program: D::Program,
         /// VAO containing the source vertex buffers.
-        vao: CustomVAO,
+        vao: D::CustomVAO,
         /// VBO for positional data, supplied as normalized `u16`.
         buf_position: VBO<[u16; 2]>,
         /// VBO for gpu block data.
@@ -958,13 +960,13 @@ enum CacheBus {
 }
 
 /// The device-specific representation of the cache texture in gpu_cache.rs
-struct CacheTexture {
+struct CacheTexture<D: DeviceMethods> {
     texture: Texture,
-    bus: CacheBus,
+    bus: CacheBus<D>,
 }
 
-impl CacheTexture {
-    fn new(device: &mut Device, use_scatter: bool) -> Result<Self, RendererError> {
+impl<D: DeviceMethods> CacheTexture<D> {
+    fn new(device: &mut D, use_scatter: bool) -> Result<Self, RendererError> {
         let texture = device.create_texture(TextureTarget::Default, ImageFormat::RGBAF32);
 
         let bus = if use_scatter {
@@ -994,13 +996,10 @@ impl CacheTexture {
             }
         };
 
-        Ok(CacheTexture {
-            texture,
-            bus,
-        })
+        Ok(CacheTexture { texture, bus })
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         device.delete_texture(self.texture);
         match self.bus {
             CacheBus::PixelBuffer { buffer, ..} => {
@@ -1021,7 +1020,7 @@ impl CacheTexture {
 
     fn prepare_for_updates(
         &mut self,
-        device: &mut Device,
+        device: &mut D,
         total_block_count: usize,
         max_height: u32,
     ) {
@@ -1085,7 +1084,7 @@ impl CacheTexture {
         }
     }
 
-    fn update(&mut self, device: &mut Device, updates: &GpuCacheUpdateList) {
+    fn update(&mut self, device: &mut D, updates: &GpuCacheUpdateList) {
         match self.bus {
             CacheBus::PixelBuffer { ref mut rows, ref mut cpu_blocks, .. } => {
                 for update in &updates.updates {
@@ -1156,7 +1155,7 @@ impl CacheTexture {
         }
     }
 
-    fn flush(&mut self, device: &mut Device) -> usize {
+    fn flush(&mut self, device: &mut D) -> usize {
         match self.bus {
             CacheBus::PixelBuffer { ref buffer, ref mut rows, ref cpu_blocks } => {
                 let rows_dirty = rows
@@ -1209,20 +1208,20 @@ impl CacheTexture {
     }
 }
 
-struct VertexDataTexture {
-    texture: Texture,
-    pbo: PBO,
+struct VertexDataTexture<D: DeviceMethods> {
+    texture: D::Texture,
+    pbo: D::PBO,
 }
 
-impl VertexDataTexture {
-    fn new(device: &mut Device) -> VertexDataTexture {
+impl<D: DeviceMethods> VertexDataTexture<D> {
+    fn new(device: &mut D) -> VertexDataTexture<D> {
         let texture = device.create_texture(TextureTarget::Default, ImageFormat::RGBAF32);
         let pbo = device.create_pbo();
 
         VertexDataTexture { texture, pbo }
     }
 
-    fn update<T>(&mut self, device: &mut Device, data: &mut Vec<T>) {
+    fn update<T>(&mut self, device: &mut D, data: &mut Vec<T>) {
         if data.is_empty() {
             return;
         }
@@ -1270,7 +1269,7 @@ impl VertexDataTexture {
             .upload(rect, 0, None, data);
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         device.delete_pbo(self.pbo);
         device.delete_texture(self.texture);
     }
@@ -1288,9 +1287,9 @@ impl FileWatcherHandler for FileWatcher {
     }
 }
 
-struct FrameOutput {
+struct FrameOutput<D: DeviceMethods> {
     last_access: FrameId,
-    fbo_id: FBOId,
+    fbo_id: D::FBOId,
 }
 
 #[derive(PartialEq)]
@@ -1301,51 +1300,51 @@ struct TargetSelector {
 }
 
 #[cfg(feature = "debug_renderer")]
-struct LazyInitializedDebugRenderer {
-    debug_renderer: Option<DebugRenderer>,
+struct LazyInitializedDebugRenderer<D: DeviceMethods> {
+    debug_renderer: Option<DebugRenderer<D>>,
 }
 
 #[cfg(feature = "debug_renderer")]
-impl LazyInitializedDebugRenderer {
+impl<D: DeviceMethods> LazyInitializedDebugRenderer<D> {
     pub fn new() -> Self {
         Self {
             debug_renderer: None,
         }
     }
 
-    pub fn get_mut<'a>(&'a mut self, device: &mut Device) -> &'a mut DebugRenderer {
+    pub fn get_mut<'a>(&'a mut self, device: &mut D) -> &'a mut DebugRenderer<D> {
         self.debug_renderer.get_or_insert_with(|| DebugRenderer::new(device))
     }
 
-    pub fn deinit(self, device: &mut Device) {
+    pub fn deinit(self, device: &mut D) {
         if let Some(debug_renderer) = self.debug_renderer {
             debug_renderer.deinit(device);
         }
     }
 }
 
-pub struct RendererVAOs {
-    prim_vao: VAO,
-    blur_vao: VAO,
-    clip_vao: VAO,
-    dash_and_dot_vao: VAO,
-    border_vao: VAO,
+pub struct RendererVAOs<D: DeviceMethods> {
+    prim_vao: D::VAO,
+    blur_vao: D::VAO,
+    clip_vao: D::VAO,
+    dash_and_dot_vao: D::VAO,
+    border_vao: D::VAO,
 }
 
 /// The renderer is responsible for submitting to the GPU the work prepared by the
 /// RenderBackend.
-pub struct Renderer {
+pub struct Renderer<D: DeviceMethods> {
     result_rx: Receiver<ResultMsg>,
     debug_server: DebugServer,
-    pub device: Device,
+    pub device: D,
     pending_texture_updates: Vec<TextureUpdateList>,
     pending_gpu_cache_updates: Vec<GpuCacheUpdateList>,
     pending_shader_updates: Vec<PathBuf>,
     active_documents: Vec<(DocumentId, RenderedDocument)>,
 
-    shaders: Shaders,
+    shaders: Shaders<D>,
 
-    pub gpu_glyph_renderer: GpuGlyphRenderer,
+    pub gpu_glyph_renderer: GpuGlyphRenderer<D>,
 
     max_texture_size: u32,
     max_recorded_profiles: usize,
@@ -1353,12 +1352,12 @@ pub struct Renderer {
     clear_color: Option<ColorF>,
     enable_clear_scissor: bool,
     #[cfg(feature = "debug_renderer")]
-    debug: LazyInitializedDebugRenderer,
+    debug: LazyInitializedDebugRenderer<D>,
     debug_flags: DebugFlags,
     backend_profile_counters: BackendProfileCounters,
     profile_counters: RendererProfileCounters,
     #[cfg(feature = "debug_renderer")]
-    profiler: Profiler,
+    profiler: Profiler<D>,
     #[cfg(feature = "debug_renderer")]
     new_frame_indicator: ChangeIndicator,
     #[cfg(feature = "debug_renderer")]
@@ -1367,12 +1366,12 @@ pub struct Renderer {
     last_time: u64,
 
     pub gpu_profile: GpuProfiler<GpuProfileTag>,
-    vaos: RendererVAOs,
+    vaos: RendererVAOs<D>,
 
-    node_data_texture: VertexDataTexture,
-    local_clip_rects_texture: VertexDataTexture,
-    render_task_texture: VertexDataTexture,
-    gpu_cache_texture: CacheTexture,
+    node_data_texture: VertexDataTexture<D>,
+    local_clip_rects_texture: VertexDataTexture<D>,
+    render_task_texture: VertexDataTexture<D>,
+    gpu_cache_texture: CacheTexture<D>,
 
     gpu_cache_frame_id: FrameId,
     gpu_cache_overflow: bool,
@@ -1380,10 +1379,10 @@ pub struct Renderer {
     pipeline_info: PipelineInfo,
 
     // Manages and resolves source textures IDs to real texture IDs.
-    texture_resolver: SourceTextureResolver,
+    texture_resolver: SourceTextureResolver<D>,
 
     // A PBO used to do asynchronous texture cache uploads.
-    texture_cache_upload_pbo: PBO,
+    texture_cache_upload_pbo: D::PBO,
 
     dither_matrix_texture: Option<Texture>,
 
@@ -1397,7 +1396,7 @@ pub struct Renderer {
     output_image_handler: Option<Box<OutputImageHandler>>,
 
     // Currently allocated FBOs for output frames.
-    output_targets: FastHashMap<u32, FrameOutput>,
+    output_targets: FastHashMap<u32, FrameOutput<D>>,
 
     pub renderer_errors: Vec<RendererError>,
 
@@ -1407,7 +1406,7 @@ pub struct Renderer {
     gpu_profiles: VecDeque<GpuProfile>,
 
     #[cfg(feature = "capture")]
-    read_fbo: FBOId,
+    read_fbo: D::FBOId,
     #[cfg(feature = "replay")]
     owned_external_images: FastHashMap<(ExternalImageId, u8), ExternalTexture>,
 }
@@ -1438,7 +1437,7 @@ impl From<ResourceCacheError> for RendererError {
     }
 }
 
-impl Renderer {
+impl<D: DeviceMethods> Renderer<D> {
     /// Initializes webrender and creates a `Renderer` and `RenderApiSender`.
     ///
     /// # Examples
@@ -1457,14 +1456,14 @@ impl Renderer {
     /// ```
     /// [rendereroptions]: struct.RendererOptions.html
     pub fn new(
-        gl: Rc<gl::Gl>,
+        init: DeviceInit,
         notifier: Box<RenderNotifier>,
         mut options: RendererOptions,
-    ) -> Result<(Self, RenderApiSender), RendererError> {
+    ) -> Result<(Renderer<D>, RenderApiSender), RendererError> {
         let (api_tx, api_rx) = channel::msg_channel()?;
         let (payload_tx, payload_rx) = channel::payload_channel()?;
         let (result_tx, result_rx) = channel();
-        let gl_type = gl.get_type();
+        let gl_type = init.get_type();
 
         let debug_server = DebugServer::new(api_tx.clone());
 
@@ -1473,8 +1472,8 @@ impl Renderer {
             notifier: notifier.clone(),
         };
 
-        let mut device = Device::new(
-            gl,
+        let mut device: D = DeviceMethods::new(
+            init,
             options.resource_override_path.clone(),
             options.upload_method.clone(),
             Box::new(file_watch_handler),
@@ -1482,7 +1481,7 @@ impl Renderer {
         );
 
         let ext_dual_source_blending = !options.disable_dual_source_blending &&
-            device.supports_extension("GL_ARB_blend_func_extended");
+            device.supports_extension( "GL_ARB_blend_func_extended");
 
         let device_max_size = device.max_texture_size();
         // 512 is the minimum that the texture cache can work with.
@@ -1746,7 +1745,7 @@ impl Renderer {
             }
         })?;
 
-        let gpu_profile = GpuProfiler::new(Rc::clone(device.rc_gl()));
+        let gpu_profile = GpuProfiler::new(Rc::clone(device.get_context()));
         #[cfg(feature = "capture")]
         let read_fbo = device.create_fbo_for_external_texture(0);
 
@@ -1819,8 +1818,8 @@ impl Renderer {
     pub fn get_graphics_api_info(&self) -> GraphicsApiInfo {
         GraphicsApiInfo {
             kind: GraphicsApi::OpenGL,
-            version: self.device.gl().get_string(gl::VERSION),
-            renderer: self.device.gl().get_string(gl::RENDERER),
+            version: self.device.version(),
+            renderer: self.device.renderer(),
         }
     }
 
@@ -3729,7 +3728,7 @@ impl Renderer {
     }
 
     #[cfg(feature = "debug_renderer")]
-    pub fn debug_renderer<'b>(&'b mut self) -> &'b mut DebugRenderer {
+    pub fn debug_renderer<'b>(&'b mut self) -> &'b mut DebugRenderer<D> {
         self.debug.get_mut(&mut self.device)
     }
 
@@ -4173,7 +4172,7 @@ struct PlainRenderer {
 
 #[cfg(feature = "replay")]
 enum CapturedExternalImageData {
-    NativeTexture(gl::GLuint),
+    NativeTexture(u32),  // It's a gl::GLuint texture handle
     Buffer(Arc<Vec<u8>>),
 }
 
@@ -4213,10 +4212,10 @@ pub struct PipelineInfo {
     pub removed_pipelines: Vec<PipelineId>,
 }
 
-impl Renderer {
+impl<D: DeviceMethods> Renderer<D> {
     #[cfg(feature = "capture")]
     fn save_texture(
-        texture: &Texture, name: &str, root: &PathBuf, device: &mut Device
+        texture: &Texture, name: &str, root: &PathBuf, device: &mut D
     ) -> PlainTexture {
         use std::fs;
         use std::io::Write;
@@ -4272,7 +4271,7 @@ impl Renderer {
     }
 
     #[cfg(feature = "replay")]
-    fn load_texture(texture: &mut Texture, plain: &PlainTexture, root: &PathBuf, device: &mut Device) -> Vec<u8> {
+    fn load_texture(texture: &mut Texture, plain: &PlainTexture, root: &PathBuf, device: &mut D) -> Vec<u8> {
         use std::fs::File;
         use std::io::Read;
 
@@ -4343,7 +4342,7 @@ impl Renderer {
                                 };
                                 info!("\t\tnative texture of target {:?}", target);
                                 let layer_index = 0; //TODO: what about layered textures?
-                                self.device.attach_read_texture_external(gl_id, target, layer_index);
+                                self.device.attach_read_texture_external(gl_id.into(), target, layer_index);
                                 let data = self.device.read_pixels(&def.descriptor);
                                 let short_path = format!("externals/t{}.raw", tex_id);
                                 (Some(data), e.insert(short_path).clone())
@@ -4483,7 +4482,7 @@ impl Renderer {
             self.gpu_cache_frame_id = renderer.gpu_cache_frame_id;
 
             info!("loading external texture-backed images");
-            let mut native_map = FastHashMap::<String, gl::GLuint>::default();
+            let mut native_map = FastHashMap::<String, u32>::default();
             for ExternalCaptureImage { short_path, external, descriptor } in renderer.external_images {
                 let target = match external.image_type {
                     ExternalImageType::TextureHandle(target) => target,
@@ -4527,10 +4526,10 @@ impl Renderer {
 }
 
 #[cfg(feature = "pathfinder")]
-fn get_vao<'a>(vertex_array_kind: VertexArrayKind,
-               vaos: &'a RendererVAOs,
-               gpu_glyph_renderer: &'a GpuGlyphRenderer)
-               -> &'a VAO {
+fn get_vao<'a, D: DeviceMethods>(vertex_array_kind: VertexArrayKind,
+                                 vaos: &'a RendererVAOs<D>,
+                                 gpu_glyph_renderer: &'a GpuGlyphRenderer<D>)
+                                 -> &'a D::VAO {
     match vertex_array_kind {
         VertexArrayKind::Primitive => &vaos.prim_vao,
         VertexArrayKind::Clip => &vaos.clip_vao,
@@ -4542,10 +4541,10 @@ fn get_vao<'a>(vertex_array_kind: VertexArrayKind,
 }
 
 #[cfg(not(feature = "pathfinder"))]
-fn get_vao<'a>(vertex_array_kind: VertexArrayKind,
-               vaos: &'a RendererVAOs,
-               _: &'a GpuGlyphRenderer)
-               -> &'a VAO {
+fn get_vao<'a, D: DeviceMethods>(vertex_array_kind: VertexArrayKind,
+                                 vaos: &'a RendererVAOs<D>,
+                                 _: &'a GpuGlyphRenderer<D>)
+                                 -> &'a D::VAO {
     match vertex_array_kind {
         VertexArrayKind::Primitive => &vaos.prim_vao,
         VertexArrayKind::Clip => &vaos.clip_vao,

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -7,7 +7,7 @@ use api::{
     YuvColorSpace, YuvFormat,
 };
 use batch::{BatchKey, BatchKind, BrushBatchKind};
-use device::{Device, Program, ShaderError};
+use device::{DeviceMethods, ShaderError};
 use euclid::{Transform3D};
 use glyph_rasterizer::GlyphFormat;
 use renderer::{
@@ -65,19 +65,19 @@ pub(crate) enum ShaderKind {
     VectorCover,
 }
 
-pub struct LazilyCompiledShader {
-    program: Option<Program>,
+pub struct LazilyCompiledShader<D: DeviceMethods> {
+    program: Option<D::Program>,
     name: &'static str,
     kind: ShaderKind,
     features: Vec<&'static str>,
 }
 
-impl LazilyCompiledShader {
+impl<D: DeviceMethods> LazilyCompiledShader<D> {
     pub(crate) fn new(
         kind: ShaderKind,
         name: &'static str,
         features: &[&'static str],
-        device: &mut Device,
+        device: &mut D,
         precache: bool,
     ) -> Result<Self, ShaderError> {
         let mut shader = LazilyCompiledShader {
@@ -107,7 +107,7 @@ impl LazilyCompiledShader {
 
     pub fn bind(
         &mut self,
-        device: &mut Device,
+        device: &mut D,
         projection: &Transform3D<f32>,
         renderer_errors: &mut Vec<RendererError>,
     ) {
@@ -122,7 +122,7 @@ impl LazilyCompiledShader {
         device.set_uniforms(program, projection);
     }
 
-    fn get(&mut self, device: &mut Device) -> Result<&Program, ShaderError> {
+    fn get(&mut self, device: &mut D) -> Result<&D::Program, ShaderError> {
         if self.program.is_none() {
             let program = match self.kind {
                 ShaderKind::Primitive | ShaderKind::Brush | ShaderKind::Text => {
@@ -159,7 +159,7 @@ impl LazilyCompiledShader {
         Ok(self.program.as_ref().unwrap())
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         if let Some(program) = self.program {
             device.delete_program(program);
         }
@@ -177,16 +177,16 @@ impl LazilyCompiledShader {
 //   pass. Assumes that AA should be applied
 //   along the primitive edge, and also that
 //   clip mask is present.
-struct BrushShader {
-    opaque: LazilyCompiledShader,
-    alpha: LazilyCompiledShader,
-    dual_source: Option<LazilyCompiledShader>,
+struct BrushShader<D: DeviceMethods> {
+    opaque: LazilyCompiledShader<D>,
+    alpha: LazilyCompiledShader<D>,
+    dual_source: Option<LazilyCompiledShader<D>>,
 }
 
-impl BrushShader {
+impl<D: DeviceMethods> BrushShader<D> {
     fn new(
         name: &'static str,
-        device: &mut Device,
+        device: &mut D,
         features: &[&'static str],
         precache: bool,
         dual_source: bool,
@@ -234,7 +234,7 @@ impl BrushShader {
         })
     }
 
-    fn get(&mut self, blend_mode: BlendMode) -> &mut LazilyCompiledShader {
+    fn get(&mut self, blend_mode: BlendMode) -> &mut LazilyCompiledShader<D> {
         match blend_mode {
             BlendMode::None => &mut self.opaque,
             BlendMode::Alpha |
@@ -250,7 +250,7 @@ impl BrushShader {
         }
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         self.opaque.deinit(device);
         self.alpha.deinit(device);
         if let Some(dual_source) = self.dual_source {
@@ -259,15 +259,15 @@ impl BrushShader {
     }
 }
 
-pub struct TextShader {
-    simple: LazilyCompiledShader,
-    glyph_transform: LazilyCompiledShader,
+pub struct TextShader<D: DeviceMethods> {
+    simple: LazilyCompiledShader<D>,
+    glyph_transform: LazilyCompiledShader<D>,
 }
 
-impl TextShader {
+impl<D: DeviceMethods> TextShader<D> {
     fn new(
         name: &'static str,
-        device: &mut Device,
+        device: &mut D,
         features: &[&'static str],
         precache: bool,
     ) -> Result<Self, ShaderError> {
@@ -296,7 +296,7 @@ impl TextShader {
     pub fn get(
         &mut self,
         glyph_format: GlyphFormat,
-    ) -> &mut LazilyCompiledShader {
+    ) -> &mut LazilyCompiledShader<D> {
         match glyph_format {
             GlyphFormat::Alpha |
             GlyphFormat::Subpixel |
@@ -307,18 +307,18 @@ impl TextShader {
         }
     }
 
-    fn deinit(self, device: &mut Device) {
+    fn deinit(self, device: &mut D) {
         self.simple.deinit(device);
         self.glyph_transform.deinit(device);
     }
 }
 
-fn create_prim_shader(
+fn create_prim_shader<D: DeviceMethods>(
     name: &'static str,
-    device: &mut Device,
+    device: &mut D,
     features: &[&'static str],
     vertex_format: VertexArrayKind,
-) -> Result<Program, ShaderError> {
+) -> Result<D::Program, ShaderError> {
     let mut prefix = format!(
         "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}\n",
         MAX_VERTEX_TEXTURE_WIDTH
@@ -363,7 +363,7 @@ fn create_prim_shader(
     program
 }
 
-fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program, ShaderError> {
+fn create_clip_shader<D: DeviceMethods>(name: &'static str, device: &mut D) -> Result<D::Program, ShaderError> {
     let prefix = format!(
         "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}\n
         #define WR_FEATURE_TRANSFORM\n",
@@ -392,30 +392,30 @@ fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program
 }
 
 
-pub struct Shaders {
+pub struct Shaders<D: DeviceMethods> {
     // These are "cache shaders". These shaders are used to
     // draw intermediate results to cache targets. The results
     // of these shaders are then used by the primitive shaders.
-    pub cs_blur_a8: LazilyCompiledShader,
-    pub cs_blur_rgba8: LazilyCompiledShader,
-    pub cs_border_segment: LazilyCompiledShader,
+    pub cs_blur_a8: LazilyCompiledShader<D>,
+    pub cs_blur_rgba8: LazilyCompiledShader<D>,
+    pub cs_border_segment: LazilyCompiledShader<D>,
 
     // Brush shaders
-    brush_solid: BrushShader,
-    brush_image: Vec<Option<BrushShader>>,
-    brush_blend: BrushShader,
-    brush_mix_blend: BrushShader,
-    brush_yuv_image: Vec<Option<BrushShader>>,
-    brush_radial_gradient: BrushShader,
-    brush_linear_gradient: BrushShader,
+    brush_solid: BrushShader<D>,
+    brush_image: Vec<Option<BrushShader<D>>>,
+    brush_blend: BrushShader<D>,
+    brush_mix_blend: BrushShader<D>,
+    brush_yuv_image: Vec<Option<BrushShader<D>>>,
+    brush_radial_gradient: BrushShader<D>,
+    brush_linear_gradient: BrushShader<D>,
 
     /// These are "cache clip shaders". These shaders are used to
     /// draw clip instances into the cached clip mask. The results
     /// of these shaders are also used by the primitive shaders.
-    pub cs_clip_rectangle: LazilyCompiledShader,
-    pub cs_clip_box_shadow: LazilyCompiledShader,
-    pub cs_clip_image: LazilyCompiledShader,
-    pub cs_clip_line: LazilyCompiledShader,
+    pub cs_clip_rectangle: LazilyCompiledShader<D>,
+    pub cs_clip_box_shadow: LazilyCompiledShader<D>,
+    pub cs_clip_image: LazilyCompiledShader<D>,
+    pub cs_clip_line: LazilyCompiledShader<D>,
 
     // The are "primitive shaders". These shaders draw and blend
     // final results on screen. They are aware of tile boundaries.
@@ -424,15 +424,15 @@ pub struct Shaders {
     // shadow primitive shader stretches the box shadow cache
     // output, and the cache_image shader blits the results of
     // a cache shader (e.g. blur) to the screen.
-    pub ps_text_run: TextShader,
-    pub ps_text_run_dual_source: TextShader,
+    pub ps_text_run: TextShader<D>,
+    pub ps_text_run_dual_source: TextShader<D>,
 
-    ps_split_composite: LazilyCompiledShader,
+    ps_split_composite: LazilyCompiledShader<D>,
 }
 
-impl Shaders {
+impl<D: DeviceMethods> Shaders<D> {
     pub fn new(
-        device: &mut Device,
+        device: &mut D,
         gl_type: GlType,
         options: &RendererOptions,
     ) -> Result<Self, ShaderError> {
@@ -671,7 +671,7 @@ impl Shaders {
             (color_space as usize)
     }
 
-    pub fn get(&mut self, key: &BatchKey) -> &mut LazilyCompiledShader {
+    pub fn get(&mut self, key: &BatchKey) -> &mut LazilyCompiledShader<D> {
         match key.kind {
             BatchKind::SplitComposite => {
                 &mut self.ps_split_composite
@@ -718,7 +718,7 @@ impl Shaders {
         }
     }
 
-    pub fn deinit(self, device: &mut Device) {
+    pub fn deinit(self, device: &mut D) {
         self.cs_blur_a8.deinit(device);
         self.cs_blur_rgba8.deinit(device);
         self.brush_solid.deinit(device);

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -147,7 +147,7 @@ pub struct Wrench {
     pub device_pixel_ratio: f32,
     page_zoom_factor: ZoomFactor,
 
-    pub renderer: webrender::Renderer,
+    pub renderer: webrender::Renderer<webrender::Device>,
     pub api: RenderApi,
     pub document_id: DocumentId,
     pub root_pipeline_id: PipelineId,


### PR DESCRIPTION
The main purpose of this PR is to receive an "in house" review before creating a PR for servo/webrender.

This pr has the following changes:

 - Moving the `Device` related code in the `device` folder.

 - In this we move the original `device.rs` into a folder and split it into three parts: public `Device` functionalities `(device_trait.rs)`,  backend related implementation `(gl.rs)`, and common structures/functionalities `(common.rs)`, which we can share between different backends.

- The `device` attribute in Renderer is replaced with a generic type which depends on the `Device` trait.

I was not sure if we should create a `gl` feature for the `gleam` related `Device` implementation as a part of this PR, or wait until we have more backend implemented.
cc @kvark @dati91 