### PR TITLE
Vertical flip the read_pixels result

### DIFF
--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -3393,13 +3393,19 @@ impl<B: hal::Backend> Device<B> {
         }
         data.truncate(output.len());
         if !capture_read && self.surface_format.base_format().0 == hal::format::SurfaceType::B8_G8_R8_A8 {
-            let mut offset = 0;
-            for _ in 0..output.len()/4 {
-                output[offset + 0] = data[offset + 2];
-                output[offset + 1] = data[offset + 1];
-                output[offset + 2] = data[offset + 0];
-                output[offset + 3] = data[offset + 3];
-                offset += 4;
+            let width = rect.size.width as usize;
+            let height = rect.size.height as usize;
+            let row_pitch : usize = bytes_per_pixel as usize * width;
+            // Vertical flip the result and convert to RGBA
+            for y in 0..height as usize {
+                for x in 0..width as usize {
+                    let offset : usize = y * row_pitch + x * 4;
+                    let rev_offset : usize = (height - 1 - y) * row_pitch + x * 4;
+                    output[offset + 0] = data[rev_offset + 2];
+                    output[offset + 1] = data[rev_offset + 1];
+                    output[offset + 2] = data[rev_offset + 0];
+                    output[offset + 3] = data[rev_offset + 3];
+                }
             }
         } else {
             output.swap_with_slice(&mut data);

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -470,11 +470,8 @@ impl<'a> ReftestHarness<'a> {
         let file = BufReader::new(File::open(filename).unwrap());
         let img_raw = load_piston_image(file, format).unwrap();
 
-        #[cfg(feature = "gl")]
         let img = img_raw.flipv().to_rgba();
 
-        #[cfg(not(feature = "gl"))]
-        let img = img_raw.to_rgba();
         let size = img.dimensions();
         ReftestImage {
             data: img.into_raw(),


### PR DESCRIPTION
We need to flip the read_pixels result in order to match the OpenGL result.
With this we don't need to modify anything in gecko in order to get proper test results.