### PR TITLE
Use dummy texture instead of external texture

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -571,10 +571,15 @@ impl<B: hal::Backend> SourceTextureResolver<B> {
                 device.bind_texture(sampler, texture);
             }
             SourceTexture::External(external_image) => {
-                let texture = self.external_images
-                    .get(&(external_image.id, external_image.channel_index))
-                    .expect(&format!("BUG: External image should be resolved by now"));
-                device.bind_external_texture(sampler, texture);
+                if cfg!(feature = "gleam") {
+                    let texture = self.external_images
+                        .get(&(external_image.id, external_image.channel_index))
+                        .expect(&format!("BUG: External image should be resolved by now"));
+                    device.bind_external_texture(sampler, texture);
+                } else {
+                    warn!("External textures are not supported");
+                    device.bind_texture(sampler, &self.dummy_cache_texture);
+                }
             }
             SourceTexture::TextureCache(index) => {
                 let texture = &self.cache_texture_map[index.0];


### PR DESCRIPTION
There are some gecko reftests which panic, because it tries to bind a texture id which non-existent in our backend,