### PR TITLE
Set scissor rect after enabling scissor with gfx

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2656,6 +2656,8 @@ impl<B: hal::Backend> Renderer<B>
 
         if scissor_rect.is_some() {
             self.device.enable_scissor();
+            #[cfg(not(feature = "gleam"))]
+            self.device.set_scissor_rect(scissor_rect.unwrap());
         }
     }
 


### PR DESCRIPTION
This one is only related to our backend, because after we disable it, we don't store the previous rect anymore, so we have to set it again.