### PR TITLE
Store SPIR-V binaries in the shader_source module

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -81,5 +81,5 @@ fn main() {
 
     let _shaders = write_shaders(glsl_files, &shaders_file);
     #[cfg(not(feature = "gleam"))]
-    gfx_main(&out_dir, _shaders);
+    gfx_main(&out_dir, _shaders, &shaders_file);
 }


### PR DESCRIPTION
Add the generated SPIR-V binaries and the content of `shader_bindings.ron` to the `shader_source` module. This is similar to what the original build script does with the shader files from the `res` folder. We need this for the testing on try server, because it can't find the `out` folder, in which these binaries are generated.