### PR TITLE
Remove cfg from clear

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3361,7 +3361,6 @@ impl<B: hal::Backend> Renderer<B>
         self.device.disable_depth_write();
         self.set_blend(false, FramebufferKind::Other);
 
-        #[cfg(feature = "gleam")]
         for rect in &target.clears {
             self.device.clear_target(Some([0.0, 0.0, 0.0, 0.0]), None, Some(*rect));
         }


### PR DESCRIPTION
This config shouldn't be there. And we only noticed now, because Gecko uses a lot more images than a wrench test.