### PR TITLE
Add missing Blur shader kind state

### DIFF
--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -1164,7 +1164,12 @@ impl<B: hal::Backend> Program<B> {
                         (BlendState::MULTIPLY, DepthTest::Off),
                     ]
                 },
-                ShaderKind::Cache(VertexArrayKind::Blur) => vec![(BlendState::Off, DepthTest::Off)],
+                ShaderKind::Cache(VertexArrayKind::Blur) => {
+                    vec![
+                        (BlendState::Off, DepthTest::Off),
+                        (BlendState::Off, LESS_EQUAL_TEST),
+                    ]
+                },
                 ShaderKind::Cache(VertexArrayKind::Border) |
                 ShaderKind::Cache(VertexArrayKind::LineDecoration) => vec![(BlendState::PREMULTIPLIED_ALPHA, DepthTest::Off)],
                 ShaderKind::ClipCache => vec![(BlendState::MULTIPLY, DepthTest::Off)],


### PR DESCRIPTION
There was a missing depth state for blur. Its needed for e.g. the developer console for gecko.