### PR TITLE
Move pipeline layouts to Device

### DIFF
--- a/webrender/src/device/mod.rs
+++ b/webrender/src/device/mod.rs
@@ -55,7 +55,7 @@ pub struct Capabilities {
     pub supports_multisampling: bool,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Eq, PartialEq, Hash, Debug, Copy, Clone)]
 pub enum ShaderKind {
     Primitive,
     Cache(VertexArrayKind),
@@ -72,7 +72,7 @@ pub enum ShaderKind {
     DebugFont,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Eq, PartialEq, Hash, Debug, Copy, Clone)]
 pub enum VertexArrayKind {
     Primitive,
     Blur,


### PR DESCRIPTION
Store pipeline layouts in `Device` instead of `Program`s, so we don't need to create multiple layout for shaders with the shame `ShaderKind`.