### PR TITLE
Wait for pending resources before deiniting device

### DIFF
--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -4671,6 +4671,7 @@ impl<B: hal::Backend> Device<B> {
     }
 
     pub fn deinit(self) {
+        self.device.wait_idle().unwrap();
         for mut texture in self.retained_textures {
             texture.id = 0;
         }


### PR DESCRIPTION
This is also needed for dx12. In some cases we crash during `Device::deinit` because some of the resources are still in flight.