### PR TITLE
Use rendy-memory for memory allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "rendy-memory"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/omni-viral/rendy.git#c5b9a5b476042d3abdf2fc838340d1f1a0d8f9e4"
 dependencies = [
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1725,6 +1725,12 @@ dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "veclist 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rendy-memory"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "rendy-memory 0.1.0 (git+https://github.com/omni-viral/rendy.git)"
 
 [[package]]
 name = "ron"
@@ -2704,6 +2710,7 @@ dependencies = [
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum relevant 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a26af7cf5c3b52f38db71875f247226949a7cda8f1441862171bf48bba256945"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rendy-memory 0.1.0 (git+https://github.com/omni-viral/rendy.git)" = "<none>"
 "checksum rendy-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cb8650615600d582ff3a15e9b6c9ba85f6be66b46d26f5511b42679f2df32e"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +869,15 @@ dependencies = [
 name = "half"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hibitset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atom 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "httparse"
@@ -1680,11 +1694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "relevant"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rendy-memory"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hibitset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relevant 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "veclist 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2099,6 +2138,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "veclist"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2245,7 @@ dependencies = [
  "png 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rendy-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2476,6 +2521,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum ash 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fadb651d8bf5fc14c936d29683798d44c4808487ba9cfac7cfd3cc7cacb58880"
+"checksum atom 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3c86699c3f02778ec07158376991c8f783dd1f2f95c579ffaf0738dc984b2fe2"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
@@ -2564,6 +2610,7 @@ dependencies = [
 "checksum glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "28caebc98746d507603a2d3df66dcbe04e41d4febad0320f3eec1ef72b6bbef1"
 "checksum glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "535c6eda58adbb227604b2db10a022ffd6339d7ea3e970f338e7d98aeb24fcc3"
 "checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
+"checksum hibitset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6527bc88f32e0d3926c7572874b2bf17a19b36978aacd0aacf75f7d27a5992d0"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
@@ -2655,7 +2702,9 @@ dependencies = [
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum relevant 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a26af7cf5c3b52f38db71875f247226949a7cda8f1441862171bf48bba256945"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rendy-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cb8650615600d582ff3a15e9b6c9ba85f6be66b46d26f5511b42679f2df32e"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -2708,6 +2757,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "600ef8213e9f8a0ac1f876e470e90780ae0478eabce7f76aff41b0f4ef0fd5c0"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum veclist 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f962bc5a4432ebd146dcd59e4e2438979ade49d7fda13a6a57f60ab0a78586e8"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum wayland-client 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "96041810afa07e7953867d46f8f03c41cbca49ebd1e840eef6abefde8b458b30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ panic = "abort"
 "https://github.com/rust-lang/crates.io-index#gfx-backend-metal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="fcc3806aba14e4c0f54adb51dd34057e192800d3" }
 "https://github.com/rust-lang/crates.io-index#gfx-backend-vulkan:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="fcc3806aba14e4c0f54adb51dd34057e192800d3" }
 "https://github.com/rust-lang/crates.io-index#gfx-hal:0.1.0" = { git = "https://github.com/gfx-rs/gfx.git", rev="fcc3806aba14e4c0f54adb51dd34057e192800d3" }
+"https://github.com/rust-lang/crates.io-index#rendy-memory:0.1.0" = { git = "https://github.com/omni-viral/rendy.git" }

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -218,6 +218,18 @@ pub fn main_wrapper<E: Example>(
         clear_color: Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
         //scatter_gpu_cache_updates: false,
         debug_flags,
+        #[cfg(feature = "gfx-hal")]
+        heaps_config: webrender::HeapsConfig {
+            linear: Some(webrender::LinearConfig {
+                linear_size: 128 * 1024 * 1024,
+            }),
+            dynamic: Some(webrender::DynamicConfig {
+                max_block_size: 256 * 1024,
+                block_size_granularity: 256,
+                blocks_per_chunk: 256,
+                max_chunk_size: 32 * 1024 * 1024,
+            })
+        },
         ..options.unwrap_or(webrender::RendererOptions::default())
     };
 

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -45,6 +45,7 @@ plane-split = "0.13.3"
 png = { optional = true, version = "0.14" }
 rand ="0.4"
 rayon = "1"
+rendy-memory = "0.1.0"
 ron = "0.1.7"
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_json = { optional = true, version = "1.0" }

--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -715,12 +715,13 @@ impl<B: hal::Backend> Buffer<B> {
         };
         let requirements = unsafe { device.get_buffer_requirements(&buffer) };
 
+        let alignment = ((requirements.alignment -1) | (alignment_mask as u64)) + 1;
         let memory_block = heaps.allocate(
             device,
             requirements.type_mask as u32,
             memory_usage,
             requirements.size,
-            std::cmp::max(requirements.alignment, (alignment_mask + 1) as u64)
+            alignment,
         ).expect("Allocate memory failed");
 
         unsafe { device.bind_buffer_memory(&memory_block.memory(), memory_block.range().start, &mut buffer) }
@@ -737,12 +738,11 @@ impl<B: hal::Backend> Buffer<B> {
     }
 
     pub fn update_all<T: Copy>(&mut self, device: &B::Device, data: &[T]) {
-        let offset = self.memory_block.range().start;
-        let length = (data.len() * std::mem::size_of::<T>()) as u64;
-        let range = offset .. offset + length;
+        let size = (data.len() * std::mem::size_of::<T>()) as u64;
+        let range = 0 ..  size;
         unsafe {
-            let mut mapped = self.memory_block.map(device, range).expect("Mapping memory block failed");
-            mapped.write(device, 0 .. length).expect("Writer creation failed").write(&data);
+            let mut mapped = self.memory_block.map(device, range.clone()).expect("Mapping memory block failed");
+            mapped.write(device, range).expect("Writer creation failed").write(&data);
         }
         self.memory_block.unmap(device);
     }
@@ -753,7 +753,7 @@ impl<B: hal::Backend> Buffer<B> {
         data: &[T],
         offset: usize,
     ) -> usize {
-        let offset = self.memory_block.range().start + (offset * self.stride) as u64;
+        let offset = (offset * self.stride) as u64;
         let size = (data.len() * self.stride) as u64;
         let range = offset .. offset + size;
         unsafe {
@@ -802,7 +802,7 @@ impl<B: hal::Backend> BufferPool<B> {
         heaps: &mut Heaps<B>,
         buffer_usage: hal::buffer::Usage,
         data_stride: usize,
-        non_coherent_atom_size: usize,
+        non_coherent_atom_size_mask: usize,
         pitch_alignment_mask: usize,
         copy_alignment_mask: usize,
     ) -> Self {
@@ -811,7 +811,7 @@ impl<B: hal::Backend> BufferPool<B> {
             heaps,
             MemoryUsageValue::Upload,
             buffer_usage,
-            std::cmp::max(pitch_alignment_mask, non_coherent_atom_size),
+            pitch_alignment_mask | non_coherent_atom_size_mask,
             TEXTURE_CACHE_SIZE,
             data_stride,
         );
@@ -921,10 +921,10 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
         device: &B::Device,
         heaps: &mut Heaps<B>,
         data_stride: usize,
-        non_coherent_atom_size: usize,
+        non_coherent_atom_size_mask: usize,
         pitch_alignment_mask: usize,
     ) -> Self {
-        let alignment_mask = std::cmp::max(non_coherent_atom_size, pitch_alignment_mask);
+        let alignment_mask = non_coherent_atom_size_mask | pitch_alignment_mask;
         let buffers = vec![InstancePoolBuffer::new(
             device,
             heaps,
@@ -2129,7 +2129,7 @@ impl<B: hal::Backend> Device<B> {
                             Some(LinearConfig {
                                 linear_size: min(
                                     128 * 1024 * 1024,
-                                    memory_properties.memory_heaps[mt.heap_index as usize] / 8,
+                                    (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
                                 ),
                             })
                         } else {
@@ -2137,14 +2137,18 @@ impl<B: hal::Backend> Device<B> {
                         },
                         dynamic: Some(DynamicConfig {
                             max_block_size: min(
-                                32 * 1024 * 1024,
-                                memory_properties.memory_heaps[mt.heap_index as usize] / 8,
+                                256 * 1024,
+                                (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
                             ),
                             block_size_granularity: min(
                                 256,
-                                memory_properties.memory_heaps[mt.heap_index as usize] / 1024,
+                                (memory_properties.memory_heaps[mt.heap_index as usize] / 1024 - 1).next_power_of_two(),
                             ),
-                            blocks_per_chunk: 64,
+                            blocks_per_chunk: 256,
+                            max_chunk_size: min(
+                                32 * 1024 * 1024,
+                                (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
+                            ),
                         }),
                     };
                     (mt.properties, mt.heap_index as u32, config)

--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -12,7 +12,7 @@ use euclid::Transform3D;
 use gpu_types;
 use internal_types::{FastHashMap, RenderTargetInfo};
 use rand::{self, Rng};
-use rendy_memory::{Block, DynamicConfig, Heaps, HeapsConfig, LinearConfig, MemoryBlock, MemoryUsageValue, Write};
+use rendy_memory::{Block, Heaps, HeapsConfig, MemoryBlock, MemoryUsageValue, Write};
 use ron::de::from_str;
 use smallvec::SmallVec;
 use std::cell::Cell;
@@ -2101,6 +2101,7 @@ impl<B: hal::Backend> Device<B> {
         resource_override_path: Option<PathBuf>,
         upload_method: UploadMethod,
         _cached_programs: Option<Rc<ProgramCache>>,
+        heaps_config: HeapsConfig,
     ) -> Self {
         let DeviceInit {
             instance,
@@ -2116,41 +2117,27 @@ impl<B: hal::Backend> Device<B> {
 
         let memory_properties = adapter.physical_device.memory_properties();
         let mut heaps = {
-            use std::cmp::min;
             let types = memory_properties.
                 memory_types
                 .iter()
                 .map(|ref mt| {
-                    let config = HeapsConfig {
-                        linear: if mt
-                            .properties
-                            .contains(gfx_hal::memory::Properties::CPU_VISIBLE)
-                        {
-                            Some(LinearConfig {
-                                linear_size: min(
-                                    128 * 1024 * 1024,
-                                    (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
-                                ),
-                            })
+                    let mut config = heaps_config;
+                    if let Some(mut linear) = config.linear {
+                        if !mt.properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE) {
+                            config.linear = None;
                         } else {
-                            None
-                        },
-                        dynamic: Some(DynamicConfig {
-                            max_block_size: min(
-                                256 * 1024,
-                                (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
-                            ),
-                            block_size_granularity: min(
-                                256,
-                                (memory_properties.memory_heaps[mt.heap_index as usize] / 1024 - 1).next_power_of_two(),
-                            ),
-                            blocks_per_chunk: 256,
-                            max_chunk_size: min(
-                                32 * 1024 * 1024,
-                                (memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two(),
-                            ),
-                        }),
-                    };
+                            linear.linear_size = linear.linear_size
+                                .min((memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two());
+                        }
+                    }
+                    if let Some(mut dynamic) = config.dynamic {
+                        dynamic.max_block_size = dynamic.max_block_size
+                            .min((memory_properties.memory_heaps[mt.heap_index as usize] / 32 - 1).next_power_of_two());
+                        dynamic.block_size_granularity = dynamic.block_size_granularity
+                            .min((memory_properties.memory_heaps[mt.heap_index as usize] / 1024 - 1).next_power_of_two());
+                        dynamic.max_chunk_size = dynamic.max_chunk_size
+                            .min((memory_properties.memory_heaps[mt.heap_index as usize] / 8 - 1).next_power_of_two());
+                    }
                     (mt.properties, mt.heap_index as u32, config)
                 });
 

--- a/webrender/src/device/gfx.rs
+++ b/webrender/src/device/gfx.rs
@@ -12,6 +12,7 @@ use euclid::Transform3D;
 use gpu_types;
 use internal_types::{FastHashMap, RenderTargetInfo};
 use rand::{self, Rng};
+use rendy_memory::{Block, DynamicConfig, Heaps, HeapsConfig, LinearConfig, MemoryBlock, MemoryUsageValue, Write};
 use ron::de::from_str;
 use smallvec::SmallVec;
 use std::cell::Cell;
@@ -439,7 +440,7 @@ const LESS_EQUAL_WRITE: DepthTest = DepthTest::On {
 
 pub struct ImageCore<B: hal::Backend> {
     pub image: B::Image,
-    pub memory: Option<B::Memory>,
+    pub memory_block: Option<MemoryBlock<B>>,
     pub view: B::ImageView,
     pub subresource_range: hal::image::SubresourceRange,
     pub state: Cell<hal::image::State>,
@@ -465,7 +466,7 @@ impl<B: hal::Backend> ImageCore<B> {
         .expect("create_image_view failed");
         ImageCore {
             image,
-            memory: None,
+            memory_block: None,
             view,
             subresource_range,
             state: Cell::new((hal::image::Access::empty(), hal::image::Layout::Undefined)),
@@ -474,7 +475,7 @@ impl<B: hal::Backend> ImageCore<B> {
 
     fn create(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
+        heaps: &mut Heaps<B>,
         kind: hal::image::Kind,
         view_kind: hal::image::ViewKind,
         mip_levels: hal::image::Level,
@@ -495,31 +496,22 @@ impl<B: hal::Backend> ImageCore<B> {
         .expect("create_image failed");
         let requirements = unsafe { device.get_image_requirements(&image) };
 
-        let mem_type = memory_types
-            .iter()
-            .enumerate()
-            .position(|(id, mem_type)| {
-                requirements.type_mask & (1 << id) != 0
-                    && mem_type
-                        .properties
-                        .contains(hal::memory::Properties::DEVICE_LOCAL)
-            })
-            .unwrap()
-            .into();
+        let memory_block = heaps.allocate(
+            device,
+            requirements.type_mask as u32,
+            MemoryUsageValue::Data,
+            requirements.size,
+            requirements.alignment
+        ).expect("Allocate memory failed");
 
-        let memory = unsafe {
-            device
-                .allocate_memory(mem_type, requirements.size)
-                .expect("Allocate memory failed")
-        };
         unsafe {
             device
-                .bind_image_memory(&memory, 0, &mut image)
+                .bind_image_memory(&memory_block.memory(), memory_block.range().start, &mut image)
                 .expect("Bind image memory failed")
         };
 
         ImageCore {
-            memory: Some(memory),
+            memory_block: Some(memory_block),
             ..Self::from_image(device, image, view_kind, format, subresource_range)
         }
     }
@@ -529,12 +521,12 @@ impl<B: hal::Backend> ImageCore<B> {
             .set((hal::image::Access::empty(), hal::image::Layout::Undefined));
     }
 
-    fn deinit(self, device: &B::Device) {
+    fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
         unsafe { device.destroy_image_view(self.view) };
-        if let Some(memory) = self.memory {
+        if let Some(memory_block) = self.memory_block {
             unsafe {
                 device.destroy_image(self.image);
-                device.free_memory(memory);
+                heaps.free(device, memory_block);
             }
         }
     }
@@ -569,7 +561,7 @@ pub struct Image<B: hal::Backend> {
 impl<B: hal::Backend> Image<B> {
     pub fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
+        heaps: &mut Heaps<B>,
         image_format: ImageFormat,
         image_width: i32,
         image_height: i32,
@@ -591,7 +583,7 @@ impl<B: hal::Backend> Image<B> {
 
         let core = ImageCore::create(
             device,
-            memory_types,
+            heaps,
             kind,
             view_kind,
             mip_levels,
@@ -691,13 +683,13 @@ impl<B: hal::Backend> Image<B> {
         }
     }
 
-    pub fn deinit(self, device: &B::Device) {
-        self.core.deinit(device);
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
+        self.core.deinit(device, heaps);
     }
 }
 
 pub struct Buffer<B: hal::Backend> {
-    pub memory: B::Memory,
+    pub memory_block: MemoryBlock<B>,
     pub buffer: B::Buffer,
     pub buffer_size: usize,
     pub buffer_len: usize,
@@ -708,8 +700,9 @@ pub struct Buffer<B: hal::Backend> {
 impl<B: hal::Backend> Buffer<B> {
     pub fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
-        usage: hal::buffer::Usage,
+        heaps: &mut Heaps<B>,
+        memory_usage: MemoryUsageValue,
+        buffer_usage: hal::buffer::Usage,
         pitch_alignment_mask: usize,
         data_len: usize,
         stride: usize,
@@ -717,66 +710,59 @@ impl<B: hal::Backend> Buffer<B> {
         let buffer_size = (data_len * stride + pitch_alignment_mask) & !pitch_alignment_mask;
         let mut buffer = unsafe {
             device
-                .create_buffer(buffer_size as u64, usage)
+                .create_buffer(buffer_size as u64, buffer_usage)
                 .expect("create_buffer failed")
         };
         let requirements = unsafe { device.get_buffer_requirements(&buffer) };
-        let memory_type = memory_types
-            .iter()
-            .enumerate()
-            .position(|(id, mem_type)| {
-                requirements.type_mask & (1 << id) != 0
-                    && mem_type
-                        .properties
-                        .contains(hal::memory::Properties::CPU_VISIBLE)
-            })
-            .unwrap()
-            .into();
-        let memory = unsafe { device.allocate_memory(memory_type, requirements.size) }
-            .expect("Allocate memory failed");
-        unsafe { device.bind_buffer_memory(&memory, 0, &mut buffer) }
+
+        let memory_block = heaps.allocate(
+            device,
+            requirements.type_mask as u32,
+            memory_usage,
+            requirements.size,
+            requirements.alignment
+        ).expect("Allocate memory failed");
+
+        unsafe { device.bind_buffer_memory(&memory_block.memory(), memory_block.range().start, &mut buffer) }
             .expect("Bind buffer memory failed");
 
-        let buffer = Buffer {
-            memory,
+        Buffer {
+            memory_block,
             buffer,
             buffer_size: requirements.size as _,
             buffer_len: data_len,
             stride,
             state: Cell::new(hal::buffer::Access::empty()),
-        };
-        buffer
+        }
     }
 
-    pub fn update_all<T: Copy>(&self, device: &B::Device, data: &[T]) {
-        let mut upload_data = unsafe {
-            device.acquire_mapping_writer::<T>(&self.memory, 0 .. self.buffer_size as u64)
+    pub fn update_all<T: Copy>(&mut self, device: &B::Device, data: &[T]) {
+        let offset = self.memory_block.range().start;
+        let length = (data.len() * std::mem::size_of::<T>()) as u64;
+        let range = offset .. offset + length;
+        unsafe {
+            let mut mapped = self.memory_block.map(device, range).expect("Mapping memory block failed");
+            mapped.write(device, 0 .. length).expect("Writer creation failed").write(&data);
         }
-        .expect("acquire_mapping_writer failed");
-        upload_data[0 .. data.len()].copy_from_slice(&data);
-        unsafe { device.release_mapping_writer(upload_data) }
-            .expect("release_mapping_writer failed");
+        self.memory_block.unmap(device);
     }
 
     pub fn update<T: Copy>(
-        &self,
+        &mut self,
         device: &B::Device,
         data: &[T],
         offset: usize,
         alignment_mask: usize,
     ) -> usize {
-        let size_aligned = (data.len() * self.stride + alignment_mask) & !alignment_mask;
-        let mut upload_data = unsafe {
-            device.acquire_mapping_writer::<T>(
-                &self.memory,
-                (offset * self.stride) as u64 .. (size_aligned + (offset * self.stride)) as u64,
-            )
+        let offset = self.memory_block.range().start + (offset * self.stride) as u64;
+        let size = (data.len() * self.stride) as u64;
+        let range = offset .. offset + size;
+        unsafe {
+            let mut mapped = self.memory_block.map(device, range).expect("Mapping memory block failed");
+            mapped.write(device, 0 .. size).expect("Writer creation failed").write(&data);
         }
-        .unwrap();
-        upload_data[0 .. data.len()].copy_from_slice(&data);
-        unsafe { device.release_mapping_writer(upload_data) }
-            .expect("release_mapping_writer failed");
-        size_aligned
+        self.memory_block.unmap(device);
+        size as usize
     }
 
     fn transit(&self, access: hal::buffer::Access) -> Option<hal::memory::Barrier<B>> {
@@ -794,10 +780,10 @@ impl<B: hal::Backend> Buffer<B> {
         }
     }
 
-    pub fn deinit(self, device: &B::Device) {
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
         unsafe {
             device.destroy_buffer(self.buffer);
-            device.free_memory(self.memory);
+            heaps.free(device, self.memory_block);
         }
     }
 }
@@ -815,8 +801,8 @@ pub struct BufferPool<B: hal::Backend> {
 impl<B: hal::Backend> BufferPool<B> {
     fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
-        usage: hal::buffer::Usage,
+        heaps: &mut Heaps<B>,
+        buffer_usage: hal::buffer::Usage,
         data_stride: usize,
         non_coherent_atom_size: usize,
         pitch_alignment_mask: usize,
@@ -824,8 +810,9 @@ impl<B: hal::Backend> BufferPool<B> {
     ) -> Self {
         let buffer = Buffer::new(
             device,
-            memory_types,
-            usage,
+            heaps,
+            MemoryUsageValue::Upload,
+            buffer_usage,
             pitch_alignment_mask,
             TEXTURE_CACHE_SIZE,
             data_stride,
@@ -873,8 +860,8 @@ impl<B: hal::Backend> BufferPool<B> {
         self.size = 0;
     }
 
-    pub fn deinit(self, device: &B::Device) {
-        self.buffer.deinit(device);
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
+        self.buffer.deinit(device, heaps);
     }
 }
 
@@ -887,15 +874,16 @@ struct InstancePoolBuffer<B: hal::Backend> {
 impl<B: hal::Backend> InstancePoolBuffer<B> {
     fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
-        usage: hal::buffer::Usage,
+        heaps: &mut Heaps<B>,
+        buffer_usage: hal::buffer::Usage,
         data_stride: usize,
         pitch_alignment_mask: usize,
     ) -> Self {
         let buffer = Buffer::new(
             device,
-            memory_types,
-            usage,
+            heaps,
+            MemoryUsageValue::Dynamic,
+            buffer_usage,
             pitch_alignment_mask,
             MAX_INSTANCE_COUNT,
             data_stride,
@@ -919,14 +907,13 @@ impl<B: hal::Backend> InstancePoolBuffer<B> {
         self.last_update_size = 0;
     }
 
-    fn deinit(self, device: &B::Device) {
-        self.buffer.deinit(device);
+    fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
+        self.buffer.deinit(device, heaps);
     }
 }
 
 pub struct InstanceBufferHandler<B: hal::Backend> {
     buffers: Vec<InstancePoolBuffer<B>>,
-    memory_types: Vec<hal::MemoryType>,
     data_stride: usize,
     non_coherent_atom_size: usize,
     pitch_alignment_mask: usize,
@@ -936,7 +923,7 @@ pub struct InstanceBufferHandler<B: hal::Backend> {
 impl<B: hal::Backend> InstanceBufferHandler<B> {
     pub fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
+        heaps: &mut Heaps<B>,
         usage: hal::buffer::Usage,
         data_stride: usize,
         non_coherent_atom_size: usize,
@@ -944,7 +931,7 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
     ) -> Self {
         let buffers = vec![InstancePoolBuffer::new(
             device,
-            memory_types,
+            heaps,
             usage,
             data_stride,
             pitch_alignment_mask,
@@ -952,7 +939,6 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
 
         InstanceBufferHandler {
             buffers,
-            memory_types: memory_types.to_vec(),
             non_coherent_atom_size,
             pitch_alignment_mask,
             data_stride,
@@ -960,7 +946,7 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
         }
     }
 
-    pub fn add<T: Copy>(&mut self, device: &B::Device, mut data: &[T]) {
+    pub fn add<T: Copy>(&mut self, device: &B::Device, mut data: &[T], heaps: &mut Heaps<B>) {
         assert_eq!(self.data_stride, mem::size_of::<T>());
         while !data.is_empty() {
             if self.current_buffer().buffer.buffer_size
@@ -970,7 +956,7 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
                 if self.buffers.len() <= self.current_buffer_index {
                     self.buffers.push(InstancePoolBuffer::new(
                         device,
-                        &self.memory_types,
+                        heaps,
                         hal::buffer::Usage::VERTEX,
                         self.data_stride,
                         self.pitch_alignment_mask,
@@ -1008,9 +994,9 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
         self.current_buffer_index = 0;
     }
 
-    fn deinit(self, device: &B::Device) {
+    fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
         for buffer in self.buffers {
-            buffer.deinit(device);
+            buffer.deinit(device, heaps);
         }
     }
 }
@@ -1018,7 +1004,6 @@ impl<B: hal::Backend> InstanceBufferHandler<B> {
 pub struct UniformBufferHandler<B: hal::Backend> {
     buffers: Vec<Buffer<B>>,
     offset: usize,
-    memory_types: Vec<hal::MemoryType>,
     usage: hal::buffer::Usage,
     data_stride: usize,
     pitch_alignment_mask: usize,
@@ -1026,7 +1011,6 @@ pub struct UniformBufferHandler<B: hal::Backend> {
 
 impl<B: hal::Backend> UniformBufferHandler<B> {
     pub fn new(
-        memory_types: &Vec<hal::MemoryType>,
         usage: hal::buffer::Usage,
         data_stride: usize,
         pitch_alignment_mask: usize,
@@ -1034,18 +1018,18 @@ impl<B: hal::Backend> UniformBufferHandler<B> {
         UniformBufferHandler {
             buffers: vec![],
             offset: 0,
-            memory_types: memory_types.clone(),
             usage,
             data_stride,
             pitch_alignment_mask,
         }
     }
 
-    pub fn add<T: Copy>(&mut self, device: &B::Device, data: &[T]) {
+    pub fn add<T: Copy>(&mut self, device: &B::Device, data: &[T], heaps: &mut Heaps<B>) {
         if self.buffers.len() == self.offset {
             self.buffers.push(Buffer::new(
                 device,
-                &self.memory_types,
+                heaps,
+                MemoryUsageValue::Dynamic,
                 self.usage,
                 self.pitch_alignment_mask,
                 data.len(),
@@ -1064,17 +1048,16 @@ impl<B: hal::Backend> UniformBufferHandler<B> {
         self.offset = 0;
     }
 
-    pub fn deinit(self, device: &B::Device) {
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
         for buffer in self.buffers {
-            buffer.deinit(device);
+            buffer.deinit(device, heaps);
         }
     }
 }
 
 pub struct VertexBufferHandler<B: hal::Backend> {
     buffer: Buffer<B>,
-    memory_types: Vec<hal::MemoryType>,
-    usage: hal::buffer::Usage,
+    buffer_usage: hal::buffer::Usage,
     data_stride: usize,
     pitch_alignment_mask: usize,
     pub buffer_len: usize,
@@ -1083,16 +1066,17 @@ pub struct VertexBufferHandler<B: hal::Backend> {
 impl<B: hal::Backend> VertexBufferHandler<B> {
     pub fn new<T: Copy>(
         device: &B::Device,
-        memory_types: &Vec<hal::MemoryType>,
-        usage: hal::buffer::Usage,
+        heaps: &mut Heaps<B>,
+        buffer_usage: hal::buffer::Usage,
         data: &[T],
         data_stride: usize,
         pitch_alignment_mask: usize,
     ) -> Self {
-        let buffer = Buffer::new(
+        let mut buffer = Buffer::new(
             device,
-            memory_types,
-            usage,
+            heaps,
+            MemoryUsageValue::Dynamic,
+            buffer_usage,
             pitch_alignment_mask,
             data.len(),
             data_stride,
@@ -1101,28 +1085,28 @@ impl<B: hal::Backend> VertexBufferHandler<B> {
         VertexBufferHandler {
             buffer_len: buffer.buffer_len,
             buffer,
-            memory_types: memory_types.clone(),
-            usage,
+            buffer_usage,
             data_stride,
             pitch_alignment_mask,
         }
     }
 
-    pub fn update<T: Copy>(&mut self, device: &B::Device, data: &[T]) {
+    pub fn update<T: Copy>(&mut self, device: &B::Device, data: &[T], heaps: &mut Heaps<B>) {
         let buffer_len = data.len() * self.data_stride;
         if self.buffer.buffer_len < buffer_len {
             let old_buffer = mem::replace(
                 &mut self.buffer,
                 Buffer::new(
                     device,
-                    &self.memory_types,
-                    self.usage,
+                    heaps,
+                    MemoryUsageValue::Dynamic,
+                    self.buffer_usage,
                     self.pitch_alignment_mask,
                     data.len(),
                     self.data_stride,
                 ),
             );
-            old_buffer.deinit(device);
+            old_buffer.deinit(device, heaps);
         }
         self.buffer.update_all(device, data);
         self.buffer_len = buffer_len;
@@ -1136,8 +1120,8 @@ impl<B: hal::Backend> VertexBufferHandler<B> {
         self.buffer_len = 0;
     }
 
-    pub fn deinit(self, device: &B::Device) {
-        self.buffer.deinit(device);
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
+        self.buffer.deinit(device, heaps);
     }
 }
 
@@ -1158,7 +1142,7 @@ impl<B: hal::Backend> Program<B> {
         pipeline_requirements: PipelineRequirements,
         device: &B::Device,
         pipeline_layout: &B::PipelineLayout,
-        memory_types: &Vec<hal::MemoryType>,
+        heaps: &mut Heaps<B>,
         limits: &hal::Limits,
         shader_name: &str,
         features: &[&str],
@@ -1392,7 +1376,7 @@ impl<B: hal::Backend> Program<B> {
         for _ in 0 .. frame_count {
             vertex_buffer.push(VertexBufferHandler::new(
                 device,
-                memory_types,
+                heaps,
                 hal::buffer::Usage::VERTEX,
                 &QUAD,
                 vertex_buffer_stride,
@@ -1400,14 +1384,13 @@ impl<B: hal::Backend> Program<B> {
             ));
             instance_buffer.push(InstanceBufferHandler::new(
                 device,
-                memory_types,
+                heaps,
                 hal::buffer::Usage::VERTEX,
                 instance_buffer_stride,
                 (limits.non_coherent_atom_size - 1) as usize,
                 (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
             ));
             locals_buffer.push(UniformBufferHandler::new(
-                memory_types,
                 hal::buffer::Usage::UNIFORM,
                 mem::size_of::<Locals>(),
                 (limits.min_uniform_buffer_offset_alignment - 1) as usize,
@@ -1415,7 +1398,7 @@ impl<B: hal::Backend> Program<B> {
             if let Some(ref mut index_buffer) = index_buffer {
                 index_buffer.push(VertexBufferHandler::new(
                     device,
-                    memory_types,
+                    heaps,
                     hal::buffer::Usage::INDEX,
                     &vec![0u32; MAX_INDEX_COUNT],
                     mem::size_of::<u32>(),
@@ -1442,16 +1425,18 @@ impl<B: hal::Backend> Program<B> {
     pub fn bind_instances<T: Copy>(
         &mut self,
         device: &B::Device,
+        heaps: &mut Heaps<B>,
         instances: &[T],
         buffer_id: usize,
     ) {
         assert!(!instances.is_empty());
-        self.instance_buffer[buffer_id].add(device, instances);
+        self.instance_buffer[buffer_id].add(device, instances, heaps);
     }
 
     fn bind_locals(
         &mut self,
         device: &B::Device,
+        heaps: &mut Heaps<B>,
         set: &B::DescriptorSet,
         projection: &Transform3D<f32>,
         u_mode: i32,
@@ -1461,7 +1446,7 @@ impl<B: hal::Backend> Program<B> {
             uTransform: projection.to_row_arrays(),
             uMode: u_mode,
         }];
-        self.locals_buffer[buffer_id].add(device, &locals_data);
+        self.locals_buffer[buffer_id].add(device, &locals_data, heaps);
         unsafe {
             device.write_descriptor_sets(vec![hal::pso::DescriptorSetWrite {
                 set,
@@ -1631,20 +1616,20 @@ impl<B: hal::Backend> Program<B> {
         }
     }
 
-    pub fn deinit(mut self, device: &B::Device) {
+    pub fn deinit(mut self, device: &B::Device, heaps: &mut Heaps<B>) {
         for mut vertex_buffer in self.vertex_buffer {
-            vertex_buffer.deinit(device);
+            vertex_buffer.deinit(device, heaps);
         }
         if let Some(index_buffer) = self.index_buffer {
             for mut index_buffer in index_buffer {
-                index_buffer.deinit(device);
+                index_buffer.deinit(device, heaps);
             }
         }
         for mut instance_buffer in self.instance_buffer {
-            instance_buffer.deinit(device);
+            instance_buffer.deinit(device, heaps);
         }
         for mut locals_buffer in self.locals_buffer {
-            locals_buffer.deinit(device);
+            locals_buffer.deinit(device, heaps);
         }
         for pipeline in self.pipelines.drain() {
             unsafe { device.destroy_graphics_pipeline(pipeline.1) };
@@ -1737,14 +1722,14 @@ pub struct DepthBuffer<B: hal::Backend> {
 impl<B: hal::Backend> DepthBuffer<B> {
     pub fn new(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
+        heaps: &mut Heaps<B>,
         pixel_width: u32,
         pixel_height: u32,
         depth_format: hal::format::Format,
     ) -> Self {
         let core = ImageCore::create(
             device,
-            memory_types,
+            heaps,
             hal::image::Kind::D2(pixel_width, pixel_height, 1, 1),
             hal::image::ViewKind::D2,
             1,
@@ -1755,8 +1740,8 @@ impl<B: hal::Backend> DepthBuffer<B> {
         DepthBuffer { core }
     }
 
-    pub fn deinit(self, device: &B::Device) {
-        self.core.deinit(device);
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>,) {
+        self.core.deinit(device, heaps);
     }
 }
 
@@ -2032,7 +2017,7 @@ impl<B: hal::Backend> CommandPool<B> {
 
 pub struct Device<B: hal::Backend> {
     pub device: B::Device,
-    pub memory_types: Vec<hal::MemoryType>,
+    heaps: Heaps<B>,
     pub limits: hal::Limits,
     adapter: hal::Adapter<B>,
     surface: Option<B::Surface>,
@@ -2136,8 +2121,45 @@ impl<B: hal::Backend> Device<B> {
         let renderer_name = "TODO renderer name".to_owned();
         let features = adapter.physical_device.features();
 
-        let memory_types = adapter.physical_device.memory_properties().memory_types;
-        println!("memory_types: {:?}", memory_types);
+        let memory_properties = adapter.physical_device.memory_properties();
+        let mut heaps = {
+            use std::cmp::min;
+            let types = memory_properties.
+                memory_types
+                .iter()
+                .map(|ref mt| {
+                    let config = HeapsConfig {
+                        linear: if mt
+                            .properties
+                            .contains(gfx_hal::memory::Properties::CPU_VISIBLE)
+                        {
+                            Some(LinearConfig {
+                                linear_size: min(
+                                    128 * 1024 * 1024,
+                                    memory_properties.memory_heaps[mt.heap_index as usize] / 8,
+                                ),
+                            })
+                        } else {
+                            None
+                        },
+                        dynamic: Some(DynamicConfig {
+                            max_block_size: min(
+                                32 * 1024 * 1024,
+                                memory_properties.memory_heaps[mt.heap_index as usize] / 8,
+                            ),
+                            block_size_granularity: min(
+                                256,
+                                memory_properties.memory_heaps[mt.heap_index as usize] / 1024,
+                            ),
+                            blocks_per_chunk: 64,
+                        }),
+                    };
+                    (mt.properties, mt.heap_index as u32, config)
+                });
+
+            let heaps = memory_properties.memory_heaps.iter().cloned();
+            unsafe { Heaps::new(types, heaps) }
+        };
 
         let limits = adapter.physical_device.limits();
         let max_texture_size = 4400i32; // TODO use limits after it points to the correct texture size
@@ -2198,7 +2220,7 @@ impl<B: hal::Backend> Device<B> {
                     frame_count,
                 ) = Device::init_swapchain_resources(
                     &device,
-                    &memory_types,
+                    &mut heaps,
                     &adapter,
                     surface,
                     window_size,
@@ -2244,7 +2266,7 @@ impl<B: hal::Backend> Device<B> {
                     for _ in 0..frame_count {
                         cores.push(ImageCore::create(
                             &device,
-                            &memory_types,
+                            &mut heaps,
                             kind,
                             hal::image::ViewKind::D2,
                             mip_levels,
@@ -2260,7 +2282,7 @@ impl<B: hal::Backend> Device<B> {
                         ));
                         frame_depths.push(DepthBuffer::new(
                             &device,
-                            &memory_types,
+                            &mut heaps,
                             extent.width,
                             extent.height,
                             depth_format,
@@ -2370,7 +2392,7 @@ impl<B: hal::Backend> Device<B> {
             command_pool.push(cp);
             staging_buffer_pool.push(BufferPool::new(
                 &device,
-                &memory_types,
+                &mut heaps,
                 hal::buffer::Usage::TRANSFER_SRC,
                 1,
                 (limits.non_coherent_atom_size - 1) as usize,
@@ -2402,8 +2424,8 @@ impl<B: hal::Backend> Device<B> {
 
         Device {
             device,
+            heaps,
             limits,
-            memory_types,
             surface_format,
             adapter,
             surface,
@@ -2505,15 +2527,15 @@ impl<B: hal::Backend> Device<B> {
         self.device.wait_idle().unwrap();
 
         for (_id, program) in self.programs.drain() {
-            program.deinit(&self.device);
+            program.deinit(&self.device, &mut self.heaps);
         }
 
         for image in self.frame_images.drain(..) {
-            image.deinit(&self.device);
+            image.deinit(&self.device, &mut self.heaps);
         }
 
         for depth in self.frame_depths.drain(..) {
-            depth.deinit(&self.device);
+            depth.deinit(&self.device, &mut self.heaps);
         }
 
         self.render_pass.take().unwrap().deinit(&self.device);
@@ -2548,7 +2570,7 @@ impl<B: hal::Backend> Device<B> {
             _frame_count,
         ) = Device::init_swapchain_resources(
             &self.device,
-            &self.memory_types,
+            &mut self.heaps,
             &self.adapter,
             self.surface.as_mut().unwrap(),
             window_size,
@@ -2578,7 +2600,7 @@ impl<B: hal::Backend> Device<B> {
 
     fn init_swapchain_resources(
         device: &B::Device,
-        memory_types: &[hal::MemoryType],
+        heaps: &mut Heaps<B>,
         adapter: &hal::Adapter<B>,
         surface: &mut B::Surface,
         window_size: (i32, i32),
@@ -2662,7 +2684,7 @@ impl<B: hal::Backend> Device<B> {
                     .map(|image| {
                         frame_depths.push(DepthBuffer::new(
                             device,
-                            &memory_types,
+                            heaps,
                             extent.width,
                             extent.height,
                             depth_format,
@@ -2981,7 +3003,7 @@ impl<B: hal::Backend> Device<B> {
                 .clone(),
             &self.device,
             &self.pipeline_layouts[shader_kind],
-            &self.memory_types,
+            &mut self.heaps,
             &self.limits,
             &name,
             features,
@@ -3067,7 +3089,7 @@ impl<B: hal::Backend> Device<B> {
             .expect("Program not found.");
 
         if let Some(ref mut index_buffer) = program.index_buffer {
-            index_buffer[self.next_id].update(&self.device, indices);
+            index_buffer[self.next_id].update(&self.device, indices, &mut self.heaps);
         } else {
             warn!("This function is for debug shaders only!");
         }
@@ -3082,7 +3104,7 @@ impl<B: hal::Backend> Device<B> {
             .expect("Program not found.");
 
         if program.shader_name.contains("debug") {
-            program.vertex_buffer[self.next_id].update(&self.device, vertices);
+            program.vertex_buffer[self.next_id].update(&self.device, vertices, &mut self.heaps);
         } else {
             warn!("This function is for debug shaders only!");
         }
@@ -3099,6 +3121,7 @@ impl<B: hal::Backend> Device<B> {
         let desc_set = &self.descriptor_pools[self.next_id].get(&program.shader_kind);
         program.bind_locals(
             &self.device,
+            &mut self.heaps,
             desc_set,
             transform,
             self.program_mode_id,
@@ -3111,7 +3134,7 @@ impl<B: hal::Backend> Device<B> {
         self.programs
             .get_mut(&self.bound_program)
             .expect("Program not found.")
-            .bind_instances(&self.device, instances, self.next_id);
+            .bind_instances(&self.device, &mut self.heaps, instances, self.next_id);
     }
 
     fn draw(&mut self) {
@@ -3421,7 +3444,7 @@ impl<B: hal::Backend> Device<B> {
         };
         let img = Image::new(
             &self.device,
-            &self.memory_types,
+            &mut self.heaps,
             texture.format,
             texture.size.width,
             texture.size.height,
@@ -3723,7 +3746,7 @@ impl<B: hal::Backend> Device<B> {
             let rbo_id = self.generate_rbo_id();
             let rbo = DepthBuffer::new(
                 &self.device,
-                &self.memory_types,
+                &mut self.heaps,
                 dimensions.width as _,
                 dimensions.height as _,
                 self.depth_format,
@@ -3749,7 +3772,7 @@ impl<B: hal::Backend> Device<B> {
         if entry.get().refcount == 0 {
             let t = entry.remove();
             let old_rbo = self.rbos.remove(&t.rbo_id).unwrap();
-            old_rbo.deinit(&self.device);
+            old_rbo.deinit(&self.device, &mut self.heaps);
             record_gpu_free(depth_target_size_in_bytes(&dimensions));
         }
     }
@@ -3977,7 +4000,7 @@ impl<B: hal::Backend> Device<B> {
 
         let image = self.images.remove(&texture.id).expect("Texture not found.");
         record_gpu_free(texture.size_in_bytes());
-        image.deinit(&self.device);
+        image.deinit(&self.device, &mut self.heaps);
     }
 
     fn delete_retained_textures(&mut self) {
@@ -4113,9 +4136,10 @@ impl<B: hal::Backend> Device<B> {
             (false, 1)
         };
 
-        let download_buffer: Buffer<B> = Buffer::new(
+        let mut download_buffer: Buffer<B> = Buffer::new(
             &self.device,
-            &self.memory_types,
+            &mut self.heaps,
+            MemoryUsageValue::Download,
             hal::buffer::Usage::TRANSFER_DST,
             (self.limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
             output.len(),
@@ -4211,36 +4235,25 @@ impl<B: hal::Backend> Device<B> {
         }
 
         let mut data = vec![0; download_buffer.buffer_size];
-
+        let range = 0 .. download_buffer.buffer_size as u64;
         if fmt_mismatch {
             let mut f32_data = vec![0f32; download_buffer.buffer_size];
-            if let Ok(reader) = unsafe {
-                self.device.acquire_mapping_reader::<f32>(
-                    &download_buffer.memory,
-                    0 .. download_buffer.buffer_size as u64,
-                )
-            } {
-                f32_data[0 .. reader.len()].copy_from_slice(&reader);
-                unsafe { self.device.release_mapping_reader(reader) };
-                assert_eq!(data.len(), f32_data.len());
-                for i in 0 .. f32_data.len() {
-                    data[i] = round_to_int(f32_data[i].min(0f32).max(1f32));
-                }
-            } else {
-                panic!("Failed to read the download buffer!");
+            unsafe {
+                let mut mapped = download_buffer.memory_block.map(&self.device, range.clone()).expect("Mapping memory block failed");
+                let slice = mapped.read(&self.device, range).expect("Read failed");
+                f32_data[0 .. slice.len()].copy_from_slice(&slice);
+            }
+            download_buffer.memory_block.unmap(&self.device);
+            for i in 0 .. f32_data.len() {
+                data[i] = round_to_int(f32_data[i].min(0f32).max(1f32));
             }
         } else {
-            if let Ok(reader) = unsafe {
-                self.device.acquire_mapping_reader::<u8>(
-                    &download_buffer.memory,
-                    0 .. download_buffer.buffer_size as u64,
-                )
-            } {
-                data[0 .. reader.len()].copy_from_slice(&reader);
-                unsafe { self.device.release_mapping_reader(reader) };
-            } else {
-                panic!("Failed to read the download buffer!");
+            unsafe {
+                let mut mapped = download_buffer.memory_block.map(&self.device, range.clone()).expect("Mapping memory block failed");
+                let slice = mapped.read(&self.device, range).expect("Read failed");
+                data[0 .. slice.len()].copy_from_slice(&slice);
             }
+            download_buffer.memory_block.unmap(&self.device);
         }
         data.truncate(output.len());
         if !capture_read && self.surface_format == ImageFormat::BGRA8
@@ -4263,7 +4276,7 @@ impl<B: hal::Backend> Device<B> {
             output.swap_with_slice(&mut data);
         }
 
-        download_buffer.deinit(&self.device);
+        download_buffer.deinit(&self.device, &mut self.heaps);
         unsafe {
             command_pool.reset();
             self.device.destroy_command_pool(command_pool.into_raw());
@@ -4842,7 +4855,7 @@ impl<B: hal::Backend> Device<B> {
         report
     }
 
-    pub fn deinit(self) {
+    pub fn deinit(mut self) {
         self.device.wait_idle().unwrap();
         for mut texture in self.retained_textures {
             texture.id = 0;
@@ -4867,6 +4880,7 @@ impl<B: hal::Backend> Device<B> {
                         .open(&self.cache_path.as_ref().unwrap())
                         .expect("File open/creation failed");
 
+                    use std::io::Write;
                     file.write(&data).expect("File write failed");
                 }
             } else {
@@ -4879,22 +4893,22 @@ impl<B: hal::Backend> Device<B> {
                 command_pool.destroy(&self.device);
             }
             for mut staging_buffer_pool in self.staging_buffer_pool {
-                staging_buffer_pool.deinit(&self.device);
+                staging_buffer_pool.deinit(&self.device, &mut self.heaps);
             }
             for image in self.frame_images {
-                image.deinit(&self.device);
+                image.deinit(&self.device, &mut self.heaps);
             }
             for depth in self.frame_depths {
-                depth.deinit(&self.device);
+                depth.deinit(&self.device, &mut self.heaps);
             }
             for (_, image) in self.images {
-                image.deinit(&self.device);
+                image.deinit(&self.device, &mut self.heaps);
             }
             for (_, rbo) in self.fbos {
                 rbo.deinit(&self.device);
             }
             for (_, rbo) in self.rbos {
-                rbo.deinit(&self.device);
+                rbo.deinit(&self.device, &mut self.heaps);
             }
             for framebuffer in self.framebuffers {
                 self.device.destroy_framebuffer(framebuffer);
@@ -4910,8 +4924,9 @@ impl<B: hal::Backend> Device<B> {
             self.descriptor_pools_global.deinit(&self.device);
             self.descriptor_pools_sampler.deinit(&self.device);
             for (_, program) in self.programs {
-                program.deinit(&self.device)
+                program.deinit(&self.device, &mut self.heaps)
             }
+            self.heaps.dispose(&self.device);
             for (_, (vs_module, fs_module)) in self.shader_modules {
                 self.device.destroy_shader_module(vs_module);
                 self.device.destroy_shader_module(fs_module);

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -214,6 +214,7 @@ pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource, Gpu
 pub use renderer::{GraphicsApi, GraphicsApiInfo, PipelineInfo, Renderer, RendererOptions};
 pub use renderer::{RendererStats, SceneBuilderHooks, ThreadListener};
 pub use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+pub use rendy_memory::{DynamicConfig, HeapsConfig, LinearConfig};
 pub use shade::{Shaders, WrShaders};
 pub use webrender_api as api;
 pub use webrender_api::euclid;

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -184,6 +184,7 @@ extern crate pathfinder_partitioner;
 extern crate pathfinder_path_utils;
 extern crate plane_split;
 extern crate rayon;
+extern crate rendy_memory;
 extern crate ron;
 #[cfg(feature = "debugger")]
 extern crate serde_json;

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -76,6 +76,8 @@ use render_backend::{FrameId, RenderBackend};
 use scene_builder::{SceneBuilder, LowPrioritySceneBuilder};
 use shade::{Shaders, WrShaders};
 use smallvec::SmallVec;
+#[cfg(not(feature = "gleam"))]
+use rendy_memory::HeapsConfig;
 use render_task::{RenderTask, RenderTaskKind, RenderTaskTree};
 use resource_cache::ResourceCache;
 use util::drain_filter;
@@ -1324,6 +1326,8 @@ impl<B: hal::Backend> Renderer<B> {
             options.resource_override_path.clone(),
             options.upload_method.clone(),
             options.cached_programs.take(),
+            #[cfg(not(feature = "gleam"))]
+            options.heaps_config,
         );
 
         #[cfg(feature = "gleam")]
@@ -4576,6 +4580,8 @@ pub struct RendererOptions {
     pub support_low_priority_transactions: bool,
     pub namespace_alloc_by_client: bool,
     pub enable_picture_caching: bool,
+    #[cfg(not(feature = "gleam"))]
+    pub heaps_config: HeapsConfig,
 }
 
 impl Default for RendererOptions {
@@ -4613,6 +4619,11 @@ impl Default for RendererOptions {
             support_low_priority_transactions: false,
             namespace_alloc_by_client: false,
             enable_picture_caching: false,
+            #[cfg(not(feature = "gleam"))]
+            heaps_config: HeapsConfig {
+                linear: None,
+                dynamic: None,
+            }
         }
     }
 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -224,6 +224,18 @@ impl Wrench {
             blob_image_handler: Some(Box::new(blob::CheckerboardRenderer::new(callbacks.clone()))),
             disable_dual_source_blending,
             chase_primitive,
+            #[cfg(feature = "gfx")]
+            heaps_config: webrender::HeapsConfig {
+                linear: Some(webrender::LinearConfig {
+                    linear_size: 128 * 1024 * 1024,
+                }),
+                dynamic: Some(webrender::DynamicConfig {
+                    max_block_size: 256 * 1024,
+                    block_size_granularity: 256,
+                    blocks_per_chunk: 256,
+                    max_chunk_size: 32 * 1024 * 1024,
+                })
+            },
             ..Default::default()
         };
 


### PR DESCRIPTION
This addresses https://github.com/szeged/webrender/issues/255
This change is not tested with Servo/Gecko yet. If those run without any memory allocation error I will remove the WIP.
If @omni-viral could take a look at these changes, I would appreciate that.
