### PR TITLE
Fix debug renderer crash with debug build

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2429,18 +2429,17 @@ impl<B: hal::Backend> Renderer<B> {
             if let Some(debug_renderer) = self.debug.try_get_mut() {
                 debug_renderer.render(&mut self.device, framebuffer_size);
             }
+
+            #[cfg(not(feature="gleam"))]
+            {
+                if !self.device.submit_to_gpu() {
+                    self.resize(None);
+                }
+            }
             self.device.end_frame();
         });
         if framebuffer_size.is_some() {
             self.last_time = current_time;
-        }
-
-        #[cfg(not(feature="gleam"))]
-        {
-            if !self.device.submit_to_gpu() {
-                self.resize(None);
-                return Ok(RendererStats::empty());
-            }
         }
 
         if self.renderer_errors.is_empty() {


### PR DESCRIPTION
Follow up to https://github.com/szeged/webrender/pull/279 .
This fixes a crash with debug build: if we resize the window we crash because we call `DebugRenderer::deinit` outside a frame, which caused a `debug_assert` to panic.
