### PR TITLE
Workaround for long rendy backtraces

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4349,8 +4349,6 @@ impl<B: hal::Backend> Renderer<B> {
             self.device.delete_external_texture(ext);
         }
         self.device.end_frame();
-        #[cfg(not(feature = "gleam"))]
-        self.device.deinit();
     }
 
     fn size_of<T>(&self, ptr: *const T) -> usize {


### PR DESCRIPTION
This patch implements the `Drop` trait for `Device<hal::Backend>`, which fixes the very long rendy-related backtraces that occur on errors and crashes.

Note: Because fields can't be moved out of types which implement the `Drop` trait (eg. in `drop()`), some of them were made into `Option` as a workaround. I'd be happy to update the code if there's a better way to implement this.