### PR TITLE
Fix the `VkBufferImageCopy-bufferOffset` validation error

### DIFF
--- a/webrender/src/device/gfx/image.rs
+++ b/webrender/src/device/gfx/image.rs
@@ -215,7 +215,7 @@ impl<B: hal::Backend> Image<B> {
         use hal::pso::PipelineStage;
         let pos = rect.origin;
         let size = rect.size;
-        staging_buffer_pool.add(device, image_data);
+        staging_buffer_pool.add(device, image_data, self.format.bytes_per_pixel() as usize - 1);
         let buffer = staging_buffer_pool.buffer();
         let cmd_buffer = cmd_pool.acquire_command_buffer();
 


### PR DESCRIPTION
This patch fix the validation error when the buffer offset is not multiple of the format's texel size.

This patch should land after the #284 PR.