### PR TITLE
[WIP] Initial implementation of runtime switching for push constants

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -192,6 +192,13 @@ pub fn main_wrapper<E: Example>(
             let cache_dir = dirs::cache_dir().expect("User's cache directory not found");
             let cache_path = Some(PathBuf::from(&cache_dir).join("pipeline_cache.bin"));
 
+            #[cfg(feature = "vulkan")]
+            let backend_api = webrender::BackendApiType::Vulkan;
+            #[cfg(feature = "metal")]
+            let backend_api = webrender::BackendApiType::Metal;
+            #[cfg(feature = "dx12")]
+            let backend_api = webrender::BackendApiType::Dx12;
+
             webrender::DeviceInit {
                 instance: Box::new(instance),
                 adapter,
@@ -200,6 +207,7 @@ pub fn main_wrapper<E: Example>(
                 descriptor_count: None,
                 cache_path,
                 save_cache: true,
+                backend_api,
             }
         };
         (window, init)

--- a/webrender/res/base.glsl
+++ b/webrender/res/base.glsl
@@ -37,6 +37,8 @@ const bool alpha_pass =
     false;
 #endif
 
+const bool push_constants = false;
+
 #if defined(GL_ES)
     #if GL_ES == 1
         #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/webrender/res/base_gfx.glsl
+++ b/webrender/res/base_gfx.glsl
@@ -7,7 +7,7 @@ layout(constant_id = 1) const bool color_target = false;
 layout(constant_id = 2) const bool glyph_transform_f = false;
 layout(constant_id = 3) const bool dithering = false;
 layout(constant_id = 4) const bool debug_overdraw = false;
-layout(constant_id = 5) const bool push_constants = false;
+layout(constant_id = 5) const bool push_constants = true;
 
 #if defined(GL_ES)
     #if GL_ES == 1

--- a/webrender/res/base_gfx.glsl
+++ b/webrender/res/base_gfx.glsl
@@ -7,6 +7,7 @@ layout(constant_id = 1) const bool color_target = false;
 layout(constant_id = 2) const bool glyph_transform_f = false;
 layout(constant_id = 3) const bool dithering = false;
 layout(constant_id = 4) const bool debug_overdraw = false;
+layout(constant_id = 5) const bool push_constants = false;
 
 #if defined(GL_ES)
     #if GL_ES == 1

--- a/webrender/src/device/gfx/descriptor.rs
+++ b/webrender/src/device/gfx/descriptor.rs
@@ -33,10 +33,7 @@ pub(super) const PER_GROUP_RANGE_DEFAULT: std::ops::Range<usize> = 8..9; // Dith
 pub(super) const PER_GROUP_RANGE_CLIP: std::ops::Range<usize> = 5..9; // GpuCache, TransformPalette, RenderTasks, Dither
 pub(super) const PER_GROUP_RANGE_PRIMITIVE: std::ops::Range<usize> = 5..11; // GpuCache, TransformPalette, RenderTasks, Dither, PrimitiveHeadersF, PrimitiveHeadersI
 
-#[cfg(feature = "push_constants")]
-pub(super) const DESCRIPTOR_SET_COUNT: usize = 3;
-#[cfg(not(feature = "push_constants"))]
-pub(super) const DESCRIPTOR_SET_COUNT: usize = 4;
+pub(super) const MAX_DESCRIPTOR_SET_COUNT: usize = 4;
 
 const fn descriptor_set_layout_binding(
     binding: u32,
@@ -67,7 +64,6 @@ pub(super) const COMMON_SET_2: &'static [DescriptorSetLayoutBinding] = &[
     descriptor_set_layout_binding(2, DT::CombinedImageSampler, SSF::ALL, false),
 ];
 
-#[cfg(not(feature = "push_constants"))]
 pub(super) const COMMON_SET_3: &'static [DescriptorSetLayoutBinding] = &[
     // Locals
     descriptor_set_layout_binding(0, DT::UniformBuffer, SSF::VERTEX, false),
@@ -170,8 +166,8 @@ pub(super) struct PerPassBindings(pub [TextureId; PER_PASS_TEXTURE_COUNT]);
 pub(super) struct PerGroupBindings(pub [TextureId; PER_GROUP_TEXTURE_COUNT]);
 
 pub(super) struct DescriptorGroupData<B: hal::Backend> {
-    pub(super) set_layouts: ArrayVec<[B::DescriptorSetLayout; DESCRIPTOR_SET_COUNT]>,
-    pub(super) ranges: ArrayVec<[DescriptorRanges; DESCRIPTOR_SET_COUNT]>,
+    pub(super) set_layouts: ArrayVec<[B::DescriptorSetLayout; MAX_DESCRIPTOR_SET_COUNT]>,
+    pub(super) ranges: ArrayVec<[DescriptorRanges; MAX_DESCRIPTOR_SET_COUNT]>,
     pub(super) pipeline_layout: B::PipelineLayout,
 }
 

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -319,7 +319,7 @@ pub struct GpuCacheUpdateList {
     /// to GPU memory.
     pub blocks: Vec<GpuBlockData>,
     /// Whole state GPU block metadata for debugging.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     pub debug_commands: Vec<GpuCacheDebugCmd>,
 }
 
@@ -426,11 +426,11 @@ struct Texture {
     allocated_block_count: usize,
     // The stamp at which we first reached our threshold for reclaiming `GpuCache`
     // memory, or `None` if the threshold hasn't been reached.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     reached_reclaim_threshold: Option<Instant>,
     // List of debug commands to be sent to the renderer when the GPU cache
     // debug display is enabled.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     debug_commands: Vec<GpuCacheDebugCmd>,
     // The current debug flags for the system.
     debug_flags: DebugFlags,

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -218,3 +218,6 @@ pub use rendy_memory::{DynamicConfig, HeapsConfig, LinearConfig};
 pub use shade::{Shaders, WrShaders};
 pub use webrender_api as api;
 pub use webrender_api::euclid;
+
+#[cfg(not(feature = "gleam"))]
+pub use device::BackendApiType;

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -468,7 +468,7 @@ pub struct TextureCache {
 
     /// A list of allocations and updates that need to be applied to the texture
     /// cache in the rendering thread this frame.
-    #[cfg_attr(all(feature = "serde", any(feature = "capture", feature = "replay")), serde(skip))]
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     pending_updates: TextureUpdateList,
 
     /// The current `FrameStamp`. Used for cache eviction policies.

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -599,6 +599,14 @@ fn main() {
             let surface = instance.create_surface(window.get_window().unwrap());
             Some(surface)
         };
+
+        #[cfg(feature = "vulkan")]
+        let backend_api = webrender::BackendApiType::Vulkan;
+        #[cfg(feature = "metal")]
+        let backend_api = webrender::BackendApiType::Metal;
+        #[cfg(feature = "dx12")]
+        let backend_api = webrender::BackendApiType::Dx12;
+
         webrender::DeviceInit {
             instance: Box::new(instance),
             adapter,
@@ -607,6 +615,7 @@ fn main() {
             descriptor_count: args.value_of("descriptor_count").map(|d| d.parse::<u32>().unwrap()),
             cache_path,
             save_cache: true,
+            backend_api,
         }
     };
 
@@ -636,7 +645,7 @@ fn main() {
     );
 
     if let Some(window_title) = wrench.take_title() {
-        if !cfg!(windows) {
+        if cfg!(not(windows)) {
             window.set_title(&window_title);
         }
     }


### PR DESCRIPTION
Continuing #282 and #291, this patch adds support for enabling/disabling push constants at initialization time. At the moment it's still work in progress, and tends to cause validation errors when run.