### PR TITLE
Fix the Rust nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ script:
 #  - servo-tidy
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_api && cargo test --verbose --features "ipc"); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --no-default-features); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --no-default-features --features capture,serde); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --features profiler,capture,serde); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --features replay,serde); fi
+  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --no-default-features --features capture); fi
+  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --features profiler,capture); fi
+  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --features replay); fi
 #  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --no-default-features --features pathfinder); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo check --verbose --no-default-features --features serialize_program); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd wrench && cargo check --verbose --features env_logger); fi

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -155,14 +155,14 @@ impl api::BlobImageHandler for CheckerboardRenderer {
 
     fn prepare_resources(
         &mut self,
-        _services: &api::BlobImageResources,
+        _services: &dyn api::BlobImageResources,
         _requests: &[api::BlobImageParams],
     ) {}
 
     fn delete_font(&mut self, _font: api::FontKey) {}
     fn delete_font_instance(&mut self, _instance: api::FontInstanceKey) {}
     fn clear_namespace(&mut self, _namespace: api::IdNamespace) {}
-    fn create_blob_rasterizer(&mut self) -> Box<api::AsyncBlobImageRasterizer> {
+    fn create_blob_rasterizer(&mut self) -> Box<dyn api::AsyncBlobImageRasterizer> {
         Box::new(Rasterizer {
             workers: Arc::clone(&self.workers),
             image_cmds: self.image_cmds.clone(),

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -47,7 +47,7 @@ impl Notifier {
 }
 
 impl RenderNotifier for Notifier {
-    fn clone(&self) -> Box<RenderNotifier> {
+    fn clone(&self) -> Box<dyn RenderNotifier> {
         Box::new(Notifier {
             events_proxy: self.events_proxy.clone(),
         })

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -53,7 +53,7 @@ impl Notifier {
 }
 
 impl RenderNotifier for Notifier {
-    fn clone(&self) -> Box<RenderNotifier> {
+    fn clone(&self) -> Box<dyn RenderNotifier> {
         Box::new(Notifier {
             events_proxy: self.events_proxy.clone(),
         })

--- a/webrender/build_gfx.rs
+++ b/webrender/build_gfx.rs
@@ -310,7 +310,7 @@ fn extend_sampler_definition(
 
     // If the sampler is in the map we only update the shader code.
     if let Some(&(_, set, binding)) = sampler_mapping.get(*sampler_name) {
-        let mut layout_str = format!(
+        let layout_str = format!(
             "layout(set = {}, binding = {}) {}{} {};\n",
             set, binding, code_str, sampler_type, sampler_name
         );
@@ -318,7 +318,7 @@ fn extend_sampler_definition(
 
     // Replace sampler definition with a texture and a sampler.
     } else {
-        let mut layout_str = format!(
+        let layout_str = format!(
             "layout(set = {}, binding = {}) {}{} {};\n",
             set, binding, code_str, sampler_type, sampler_name
         );

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -96,7 +96,7 @@ const QUAD: [vertex_types::Vertex; 6] = [
 ];
 
 pub struct DeviceInit<B: hal::Backend> {
-    pub instance: Box<hal::Instance<Backend = B>>,
+    pub instance: Box<dyn hal::Instance<Backend = B>>,
     pub adapter: hal::Adapter<B>,
     pub surface: Option<B::Surface>,
     pub window_size: (i32, i32),
@@ -152,7 +152,7 @@ pub struct Device<B: hal::Backend> {
     pub limits: hal::Limits,
     adapter: hal::Adapter<B>,
     surface: Option<B::Surface>,
-    _instance: Box<hal::Instance<Backend = B>>,
+    _instance: Box<dyn hal::Instance<Backend = B>>,
     pub surface_format: ImageFormat,
     pub depth_format: hal::format::Format,
     pub queue_group_family: QueueFamilyId,
@@ -3625,11 +3625,11 @@ impl<B: hal::Backend> Device<B> {
             for command_pool in self.command_pool {
                 command_pool.destroy(&self.device);
             }
-            for mut staging_buffer_pool in self.staging_buffer_pool {
+            for staging_buffer_pool in self.staging_buffer_pool {
                 staging_buffer_pool.deinit(&self.device, &mut self.heaps);
             }
             self.quad_buffer.deinit(&self.device, &mut self.heaps);
-            for mut instance_buffer in self.instance_buffers {
+            for instance_buffer in self.instance_buffers {
                 instance_buffer.deinit(&self.device, &mut self.heaps);
             }
             for buffer in self.free_instance_buffers {

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -457,12 +457,12 @@ impl<B: hal::Backend> Program<B> {
 
     pub(super) fn deinit(mut self, device: &B::Device, heaps: &mut Heaps<B>) {
         if let Some(vertex_buffer) = self.vertex_buffer {
-            for mut vertex_buffer in vertex_buffer {
+            for vertex_buffer in vertex_buffer {
                 vertex_buffer.deinit(device, heaps);
             }
         }
         if let Some(index_buffer) = self.index_buffer {
-            for mut index_buffer in index_buffer {
+            for index_buffer in index_buffer {
                 index_buffer.deinit(device, heaps);
             }
         }

--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -43,7 +43,7 @@ const SHADER_VERSION_GLES: &str = "#version 300 es\n";
 const DEFAULT_TEXTURE: TextureSlot = TextureSlot(0);
 
 pub struct DeviceInit<B> {
-    pub gl: Rc<gl::Gl>,
+    pub gl: Rc<dyn gl::Gl>,
     pub phantom_data: PhantomData<B>,
 }
 
@@ -79,7 +79,7 @@ fn supports_extension(extensions: &[String], extension: &str) -> bool {
     extensions.iter().any(|s| s == extension)
 }
 
-pub(crate) fn get_shader_version(gl: &gl::Gl) -> &'static str {
+pub(crate) fn get_shader_version(gl: &dyn gl::Gl) -> &'static str {
     match gl.get_type() {
         gl::GlType::Gl => SHADER_VERSION_GL,
         gl::GlType::Gles => SHADER_VERSION_GLES,
@@ -119,7 +119,7 @@ impl VertexAttribute {
         divisor: gl::GLuint,
         stride: gl::GLint,
         offset: gl::GLuint,
-        gl: &gl::Gl,
+        gl: &dyn gl::Gl,
     ) {
         gl.enable_vertex_attrib_array(attr_index);
         gl.vertex_attrib_divisor(attr_index, divisor);
@@ -189,7 +189,7 @@ impl VertexDescriptor {
         attributes: &[VertexAttribute],
         start_index: usize,
         divisor: u32,
-        gl: &gl::Gl,
+        gl: &dyn gl::Gl,
         vbo: VBOId,
     ) {
         vbo.bind(gl);
@@ -207,7 +207,7 @@ impl VertexDescriptor {
         }
     }
 
-    fn bind(&self, gl: &gl::Gl, main: VBOId, instance: VBOId) {
+    fn bind(&self, gl: &dyn gl::Gl, main: VBOId, instance: VBOId) {
         Self::bind_attributes(self.vertex_attributes, 0, 0, gl, main);
 
         if !self.instance_attributes.is_empty() {
@@ -221,19 +221,19 @@ impl VertexDescriptor {
 }
 
 impl VBOId {
-    fn bind(&self, gl: &gl::Gl) {
+    fn bind(&self, gl: &dyn gl::Gl) {
         gl.bind_buffer(gl::ARRAY_BUFFER, self.0);
     }
 }
 
 impl IBOId {
-    fn bind(&self, gl: &gl::Gl) {
+    fn bind(&self, gl: &dyn gl::Gl) {
         gl.bind_buffer(gl::ELEMENT_ARRAY_BUFFER, self.0);
     }
 }
 
 impl FBOId {
-    fn bind(&self, gl: &gl::Gl, target: FBOTarget) {
+    fn bind(&self, gl: &dyn gl::Gl, target: FBOTarget) {
         let target = match target {
             FBOTarget::Read => gl::READ_FRAMEBUFFER,
             FBOTarget::Draw => gl::DRAW_FRAMEBUFFER,
@@ -447,7 +447,7 @@ enum TexStorageUsage {
 }
 
 pub struct Device<B> {
-    gl: Rc<gl::Gl>,
+    gl: Rc<dyn gl::Gl>,
     // device state
     bound_textures: [gl::GLuint; 16],
     bound_program: gl::GLuint,
@@ -663,11 +663,11 @@ impl<B> Device<B> {
         }
     }
 
-    pub fn gl(&self) -> &gl::Gl {
+    pub fn gl(&self) -> &dyn gl::Gl {
         &*self.gl
     }
 
-    pub fn rc_gl(&self) -> &Rc<gl::Gl> {
+    pub fn rc_gl(&self) -> &Rc<dyn gl::Gl> {
         &self.gl
     }
 
@@ -727,7 +727,7 @@ impl<B> Device<B> {
     }
 
     pub fn compile_shader(
-        gl: &gl::Gl,
+        gl: &dyn gl::Gl,
         name: &str,
         shader_type: gl::GLenum,
         source: &String,
@@ -2441,7 +2441,7 @@ impl PixelBuffer {
 }
 
 struct UploadTarget<'a> {
-    gl: &'a gl::Gl,
+    gl: &'a dyn gl::Gl,
     bgra_format: gl::GLuint,
     texture: &'a Texture,
 }

--- a/webrender/src/device/mod.rs
+++ b/webrender/src/device/mod.rs
@@ -94,7 +94,7 @@ pub struct TextureSlot(pub usize);
 
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum TextureFilter {
     Nearest,
@@ -442,11 +442,11 @@ pub struct ProgramCache {
     /// Optional trait object that allows the client
     /// application to handle ProgramCache updating
     #[cfg(feature="gleam")]
-    program_cache_handler: Option<Box<ProgramCacheObserver>>,
+    program_cache_handler: Option<Box<dyn ProgramCacheObserver>>,
 }
 
 impl ProgramCache {
-    pub fn new(_program_cache_observer: Option<Box<ProgramCacheObserver>>) -> Rc<Self> {
+    pub fn new(_program_cache_observer: Option<Box<dyn ProgramCacheObserver>>) -> Rc<Self> {
         Rc::new(
             ProgramCache {
                 entries: RefCell::new(FastHashMap::default()),

--- a/webrender/src/device/query_gl.rs
+++ b/webrender/src/device/query_gl.rs
@@ -64,7 +64,7 @@ impl<T> QuerySet<T> {
 }
 
 pub struct GpuFrameProfile<T> {
-    gl: Rc<gl::Gl>,
+    gl: Rc<dyn gl::Gl>,
     timers: QuerySet<GpuTimer<T>>,
     samplers: QuerySet<GpuSampler<T>>,
     frame_id: GpuFrameId,
@@ -73,7 +73,7 @@ pub struct GpuFrameProfile<T> {
 }
 
 impl<T> GpuFrameProfile<T> {
-    fn new(gl: Rc<gl::Gl>, ext_debug_marker: bool) -> Self {
+    fn new(gl: Rc<dyn gl::Gl>, ext_debug_marker: bool) -> Self {
         GpuFrameProfile {
             gl,
             timers: QuerySet::new(),
@@ -183,14 +183,14 @@ impl<T> Drop for GpuFrameProfile<T> {
 }
 
 pub struct GpuProfiler<T> {
-    gl: Rc<gl::Gl>,
+    gl: Rc<dyn gl::Gl>,
     frames: Vec<GpuFrameProfile<T>>,
     next_frame: usize,
     ext_debug_marker: bool
 }
 
 impl<T> GpuProfiler<T> {
-    pub fn new(gl: Rc<gl::Gl>, ext_debug_marker: bool) -> Self {
+    pub fn new(gl: Rc<dyn gl::Gl>, ext_debug_marker: bool) -> Self {
         const MAX_PROFILE_FRAMES: usize = 4;
         let frames = (0 .. MAX_PROFILE_FRAMES)
             .map(|_| GpuFrameProfile::new(Rc::clone(&gl), ext_debug_marker))
@@ -273,11 +273,11 @@ impl<T: NamedTag> GpuProfiler<T> {
 
 #[must_use]
 pub struct GpuMarker {
-    gl: Option<Rc<gl::Gl>>
+    gl: Option<Rc<dyn gl::Gl>>
 }
 
 impl GpuMarker {
-    fn new(gl: &Rc<gl::Gl>, message: &str, ext_debug_marker: bool) -> Self {
+    fn new(gl: &Rc<dyn gl::Gl>, message: &str, ext_debug_marker: bool) -> Self {
         let gl = if ext_debug_marker {
             gl.push_group_marker_ext(message);
             Some(Rc::clone(gl))
@@ -287,7 +287,7 @@ impl GpuMarker {
         GpuMarker { gl }
     }
 
-    fn fire(gl: &Rc<gl::Gl>, message: &str, ext_debug_marker: bool) {
+    fn fire(gl: &Rc<dyn gl::Gl>, message: &str, ext_debug_marker: bool) {
         if ext_debug_marker {
             gl.insert_event_marker_ext(message);
         }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -892,7 +892,7 @@ impl<'a> DisplayListFlattener<'a> {
                 // refer to another user defined clip-chain. If none is specified,
                 // the parent is the root clip-chain for the given pipeline. This
                 // is used to provide a root clip chain for iframes.
-                let mut parent_clip_chain_id = match info.parent {
+                let parent_clip_chain_id = match info.parent {
                     Some(id) => {
                         self.id_to_index_mapper.get_clip_chain_id(ClipId::ClipChain(id))
                     }

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -352,9 +352,9 @@ impl SubpixelOffset {
         let apos = ((pos - pos.floor()) * 8.0) as i32;
 
         match apos {
-            1...2 => SubpixelOffset::Quarter,
-            3...4 => SubpixelOffset::Half,
-            5...6 => SubpixelOffset::ThreeQuarters,
+            1..=2 => SubpixelOffset::Quarter,
+            3..=4 => SubpixelOffset::Half,
+            5..=6 => SubpixelOffset::ThreeQuarters,
             _ => SubpixelOffset::Zero,
         }
     }

--- a/webrender/src/glyph_rasterizer/no_pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/no_pathfinder.rs
@@ -58,7 +58,7 @@ impl GlyphRasterizer {
         // select glyphs that have not been requested yet.
         for key in glyph_keys {
             match glyph_key_cache.entry(key.clone()) {
-                Entry::Occupied(mut entry) => {
+                Entry::Occupied(entry) => {
                     let value = entry.into_mut();
                     match *value {
                         GlyphCacheEntry::Cached(ref glyph) => {

--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -406,7 +406,7 @@ mod tests {
         visible_rect: &LayoutRect,
         device_image_size: &DeviceIntSize,
         device_tile_size: i32,
-        callback: &mut FnMut(&LayoutRect, TileOffset, EdgeAaSegmentMask),
+        callback: &mut dyn FnMut(&LayoutRect, TileOffset, EdgeAaSegmentMask),
     ) {
         let mut coverage = LayoutRect::zero();
         let mut seen_tiles = HashSet::new();

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -39,7 +39,7 @@ pub type PlaneSplitter = BspSplitter<f64, WorldPixel>;
 ///
 /// We never reuse IDs, so we use a u64 here to be safe.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct CacheTextureId(pub u64);
 
@@ -63,7 +63,7 @@ pub type LayerIndex = usize;
 /// preserved in a list until the end of the frame, and this type specifies the
 /// index in that list.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct SavedTargetIndex(pub usize);
 
@@ -73,7 +73,7 @@ impl SavedTargetIndex {
 
 /// Identifies the source of an input texture to a shader.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum TextureSource {
     /// Equivalent to `None`, allowing us to avoid using `Option`s everywhere.
@@ -99,13 +99,14 @@ pub const ORTHO_FAR_PLANE: f32 = 100000.0;
 pub const ORTHO_FAR_PLANE: f32 = 000000.0;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct RenderTargetInfo {
     pub has_depth: bool,
 }
 
 #[derive(Debug)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub enum TextureUpdateSource {
     External {
         id: ExternalImageId,
@@ -119,6 +120,7 @@ pub enum TextureUpdateSource {
 
 /// Command to allocate, reallocate, or free a texture for the texture cache.
 #[derive(Debug)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub struct TextureCacheAllocation {
     /// The virtual ID (i.e. distinct from device ID) of the texture.
     pub id: CacheTextureId,
@@ -128,6 +130,7 @@ pub struct TextureCacheAllocation {
 
 /// Information used when allocating / reallocating.
 #[derive(Debug)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub struct TextureCacheAllocInfo {
     pub width: i32,
     pub height: i32,
@@ -140,6 +143,7 @@ pub struct TextureCacheAllocInfo {
 
 /// Sub-operation-specific information for allocation operations.
 #[derive(Debug)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub enum TextureCacheAllocationKind {
     /// Performs an initial texture allocation.
     Alloc(TextureCacheAllocInfo),
@@ -153,6 +157,7 @@ pub enum TextureCacheAllocationKind {
 
 /// Command to update the contents of the texture cache.
 #[derive(Debug)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub struct TextureCacheUpdate {
     pub id: CacheTextureId,
     pub rect: DeviceIntRect,
@@ -168,6 +173,7 @@ pub struct TextureCacheUpdate {
 /// The list of allocation operations is processed before the updates. This is
 /// important to allow coalescing of certain allocation operations.
 #[derive(Default)]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 pub struct TextureUpdateList {
     /// Commands to alloc/realloc/free the textures. Processed first.
     pub allocations: Vec<TextureCacheAllocation>,

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -2882,7 +2882,7 @@ fn decompose_repeated_primitive(
     prim_context: &PrimitiveContext,
     frame_state: &mut FrameBuildingState,
     gradient_tiles: &mut GradientTileStorage,
-    callback: &mut FnMut(&LayoutRect, GpuDataRequest),
+    callback: &mut dyn FnMut(&LayoutRect, GpuDataRequest),
 ) -> GradientTileRange {
     let mut visible_tiles = Vec::new();
     let world_rect = frame_state.current_dirty_region().combined.world_rect;

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -1049,7 +1049,7 @@ impl Profiler {
     ) {
         Profiler::draw_counters(
             &[
-                &renderer_profile.frame_time as &ProfileCounter,
+                &renderer_profile.frame_time as &dyn ProfileCounter,
                 &renderer_profile.color_targets,
                 &renderer_profile.alpha_targets,
                 &renderer_profile.draw_calls,
@@ -1077,7 +1077,7 @@ impl Profiler {
     ) {
         Profiler::draw_counters(
             &[
-                &renderer_profile.frame_time as &ProfileCounter,
+                &renderer_profile.frame_time as &dyn ProfileCounter,
                 &renderer_profile.frame_counter,
                 &renderer_profile.color_targets,
                 &renderer_profile.alpha_targets,
@@ -1173,8 +1173,8 @@ impl Profiler {
                 description: "Total",
                 value: total,
             });
-            let samplers: Vec<&ProfileCounter> = samplers.iter().map(|sampler| {
-                sampler as &ProfileCounter
+            let samplers: Vec<&dyn ProfileCounter> = samplers.iter().map(|sampler| {
+                sampler as &dyn ProfileCounter
             }).collect();
             Profiler::draw_counters(
                 &samplers,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -84,7 +84,7 @@ impl DocumentView {
 }
 
 #[derive(Copy, Clone, Hash, MallocSizeOf, PartialEq, PartialOrd, Debug, Eq, Ord)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct FrameId(usize);
 
@@ -679,9 +679,9 @@ pub struct RenderBackend {
     frame_config: FrameBuilderConfig,
     documents: FastHashMap<DocumentId, Document>,
 
-    notifier: Box<RenderNotifier>,
-    recorder: Option<Box<ApiRecordingReceiver>>,
-    sampler: Option<Box<AsyncPropertySampler + Send>>,
+    notifier: Box<dyn RenderNotifier>,
+    recorder: Option<Box<dyn ApiRecordingReceiver>>,
+    sampler: Option<Box<dyn AsyncPropertySampler + Send>>,
     size_of_ops: Option<MallocSizeOfOps>,
     debug_flags: DebugFlags,
     namespace_alloc_by_client: bool,
@@ -699,10 +699,10 @@ impl RenderBackend {
         scene_rx: Receiver<SceneBuilderResult>,
         default_device_pixel_ratio: f32,
         resource_cache: ResourceCache,
-        notifier: Box<RenderNotifier>,
+        notifier: Box<dyn RenderNotifier>,
         frame_config: FrameBuilderConfig,
-        recorder: Option<Box<ApiRecordingReceiver>>,
-        sampler: Option<Box<AsyncPropertySampler + Send>>,
+        recorder: Option<Box<dyn ApiRecordingReceiver>>,
+        sampler: Option<Box<dyn AsyncPropertySampler + Send>>,
         size_of_ops: Option<MallocSizeOfOps>,
         debug_flags: DebugFlags,
         namespace_alloc_by_client: bool,
@@ -857,7 +857,7 @@ impl RenderBackend {
 
                             doc.removed_pipelines.append(&mut txn.removed_pipelines);
 
-                            if let Some(mut built_scene) = txn.built_scene.take() {
+                            if let Some(built_scene) = txn.built_scene.take() {
                                 doc.new_async_scene_ready(
                                     built_scene,
                                     &mut self.recycler,
@@ -1730,7 +1730,7 @@ impl RenderBackend {
             let data_stores = CaptureConfig::deserialize::<DataStores, _>(root, &data_stores_name)
                 .expect(&format!("Unable to open {}.ron", data_stores_name));
 
-            let mut doc = Document {
+            let doc = Document {
                 scene: scene.clone(),
                 removed_pipelines: Vec::new(),
                 view: view.clone(),

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1233,12 +1233,12 @@ pub struct Renderer<B: hal::Backend> {
 
     /// Optional trait object that allows the client
     /// application to provide external buffers for image data.
-    external_image_handler: Option<Box<ExternalImageHandler>>,
+    external_image_handler: Option<Box<dyn ExternalImageHandler>>,
 
     /// Optional trait object that allows the client
     /// application to provide a texture handle to
     /// copy the WR output to.
-    output_image_handler: Option<Box<OutputImageHandler>>,
+    output_image_handler: Option<Box<dyn OutputImageHandler>>,
 
     /// Optional function pointers for measuring memory used by a given
     /// heap-allocated pointer.
@@ -1312,7 +1312,7 @@ impl<B: hal::Backend> Renderer<B> {
     /// [rendereroptions]: struct.RendererOptions.html
     pub fn new(
         init: DeviceInit<B>,
-        notifier: Box<RenderNotifier>,
+        notifier: Box<dyn RenderNotifier>,
         mut options: RendererOptions,
         shaders: Option<&mut WrShaders<B>>
     ) -> Result<(Self, RenderApiSender), RendererError> {
@@ -1445,7 +1445,7 @@ impl<B: hal::Backend> Renderer<B> {
                 21,
             ];
 
-            let mut texture = device.create_texture(
+            let texture = device.create_texture(
                 TextureTarget::Default,
                 ImageFormat::R8,
                 8,
@@ -1782,7 +1782,7 @@ impl<B: hal::Backend> Renderer<B> {
                 }
                 ResultMsg::PublishDocument(
                     document_id,
-                    mut doc,
+                    doc,
                     texture_update_list,
                     profile_counters,
                 ) => {
@@ -2141,12 +2141,12 @@ impl<B: hal::Backend> Renderer<B> {
     }
 
     /// Set a callback for handling external images.
-    pub fn set_external_image_handler(&mut self, handler: Box<ExternalImageHandler>) {
+    pub fn set_external_image_handler(&mut self, handler: Box<dyn ExternalImageHandler>) {
         self.external_image_handler = Some(handler);
     }
 
     /// Set a callback for handling external outputs.
-    pub fn set_output_image_handler(&mut self, handler: Box<OutputImageHandler>) {
+    pub fn set_output_image_handler(&mut self, handler: Box<dyn OutputImageHandler>) {
         self.output_image_handler = Some(handler);
     }
 
@@ -4086,7 +4086,7 @@ impl<B: hal::Backend> Renderer<B> {
         mut textures: Vec<&Texture>,
         framebuffer_size: DeviceIntSize,
         bottom: i32,
-        select_color: &Fn(&Texture) -> [f32; 4],
+        select_color: &dyn Fn(&Texture) -> [f32; 4],
     ) {
         let mut spacing = 16;
         let mut size = 512;
@@ -4531,17 +4531,17 @@ pub struct RendererOptions {
     pub scatter_gpu_cache_updates: bool,
     pub upload_method: UploadMethod,
     pub workers: Option<Arc<ThreadPool>>,
-    pub blob_image_handler: Option<Box<BlobImageHandler>>,
-    pub recorder: Option<Box<ApiRecordingReceiver>>,
-    pub thread_listener: Option<Box<ThreadListener + Send + Sync>>,
+    pub blob_image_handler: Option<Box<dyn BlobImageHandler>>,
+    pub recorder: Option<Box<dyn ApiRecordingReceiver>>,
+    pub thread_listener: Option<Box<dyn ThreadListener + Send + Sync>>,
     pub size_of_op: Option<VoidPtrToSizeFn>,
     pub enclosing_size_of_op: Option<VoidPtrToSizeFn>,
     pub cached_programs: Option<Rc<ProgramCache>>,
     pub debug_flags: DebugFlags,
     pub renderer_id: Option<u64>,
     pub disable_dual_source_blending: bool,
-    pub scene_builder_hooks: Option<Box<SceneBuilderHooks + Send>>,
-    pub sampler: Option<Box<AsyncPropertySampler + Send>>,
+    pub scene_builder_hooks: Option<Box<dyn SceneBuilderHooks + Send>>,
+    pub sampler: Option<Box<dyn AsyncPropertySampler + Send>>,
     pub chase_primitive: ChasePrimitive,
     pub support_low_priority_transactions: bool,
     pub namespace_alloc_by_client: bool,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -457,7 +457,7 @@ pub struct ResourceCache {
     /// both blobs and regular images.
     pending_image_requests: FastHashSet<ImageRequest>,
 
-    blob_image_handler: Option<Box<BlobImageHandler>>,
+    blob_image_handler: Option<Box<dyn BlobImageHandler>>,
     rasterized_blob_images: FastHashMap<BlobImageKey, RasterizedBlob>,
     blob_image_templates: FastHashMap<BlobImageKey, BlobImageTemplate>,
 
@@ -465,7 +465,7 @@ pub struct ResourceCache {
     /// rasterize, add them to this list and rasterize them synchronously.
     missing_blob_images: Vec<BlobImageParams>,
     /// The rasterizer associated with the current scene.
-    blob_image_rasterizer: Option<Box<AsyncBlobImageRasterizer>>,
+    blob_image_rasterizer: Option<Box<dyn AsyncBlobImageRasterizer>>,
     /// An epoch of the stored blob image rasterizer, used to skip the ones
     /// coming from low-priority scene builds if the current one is newer.
     /// This is to be removed when we get rid of the whole "missed" blob
@@ -484,7 +484,7 @@ impl ResourceCache {
     pub fn new(
         texture_cache: TextureCache,
         glyph_rasterizer: GlyphRasterizer,
-        blob_image_handler: Option<Box<BlobImageHandler>>,
+        blob_image_handler: Option<Box<dyn BlobImageHandler>>,
     ) -> Self {
         ResourceCache {
             cached_glyphs: GlyphCache::new(),
@@ -681,7 +681,7 @@ impl ResourceCache {
     }
 
     pub fn set_blob_rasterizer(
-        &mut self, rasterizer: Box<AsyncBlobImageRasterizer>,
+        &mut self, rasterizer: Box<dyn AsyncBlobImageRasterizer>,
         supp: AsyncBlobImageInfo,
     ) {
         if self.blob_image_rasterizer_consumed_epoch.0 < supp.epoch.0 {
@@ -1156,7 +1156,7 @@ impl ResourceCache {
     pub fn create_blob_scene_builder_requests(
         &mut self,
         keys: &[BlobImageKey]
-    ) -> (Option<(Box<AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>, Vec<BlobImageParams>) {
+    ) -> (Option<(Box<dyn AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>, Vec<BlobImageParams>) {
         if self.blob_image_handler.is_none() || keys.is_empty() {
             return (None, Vec::new());
         }

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -43,7 +43,7 @@ pub struct Transaction {
     pub epoch_updates: Vec<(PipelineId, Epoch)>,
     pub request_scene_build: Option<SceneRequest>,
     pub blob_requests: Vec<BlobImageParams>,
-    pub blob_rasterizer: Option<(Box<AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>,
+    pub blob_rasterizer: Option<(Box<dyn AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>,
     pub rasterized_blobs: Vec<(BlobImageRequest, BlobImageResult)>,
     pub resource_updates: Vec<ResourceUpdate>,
     pub frame_ops: Vec<FrameMsg>,
@@ -88,7 +88,7 @@ pub struct BuiltTransaction {
     pub built_scene: Option<BuiltScene>,
     pub resource_updates: Vec<ResourceUpdate>,
     pub rasterized_blobs: Vec<(BlobImageRequest, BlobImageResult)>,
-    pub blob_rasterizer: Option<(Box<AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>,
+    pub blob_rasterizer: Option<(Box<dyn AsyncBlobImageRasterizer>, AsyncBlobImageInfo)>,
     pub frame_ops: Vec<FrameMsg>,
     pub removed_pipelines: Vec<PipelineId>,
     pub notifications: Vec<NotificationRequest>,
@@ -276,7 +276,7 @@ pub struct SceneBuilder {
     tx: Sender<SceneBuilderResult>,
     api_tx: MsgSender<ApiMsg>,
     config: FrameBuilderConfig,
-    hooks: Option<Box<SceneBuilderHooks + Send>>,
+    hooks: Option<Box<dyn SceneBuilderHooks + Send>>,
     simulate_slow_ms: u32,
     size_of_ops: Option<MallocSizeOfOps>,
 }
@@ -285,7 +285,7 @@ impl SceneBuilder {
     pub fn new(
         config: FrameBuilderConfig,
         api_tx: MsgSender<ApiMsg>,
-        hooks: Option<Box<SceneBuilderHooks + Send>>,
+        hooks: Option<Box<dyn SceneBuilderHooks + Send>>,
         size_of_ops: Option<MallocSizeOfOps>,
     ) -> (Self, Sender<SceneBuilderRequest>, Receiver<SceneBuilderResult>) {
         let (in_tx, in_rx) = channel();

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -707,12 +707,12 @@ impl<B: hal::Backend> Shaders<B> {
         self.cs_line_decoration.reset();
         self.ps_text_run.reset();
         self.ps_text_run_dual_source.reset();
-        for mut shader in &mut self.brush_image {
+        for shader in &mut self.brush_image {
             if let Some(ref mut shader) = shader {
                 shader.reset();
             }
         }
-        for mut shader in &mut self.brush_yuv_image {
+        for shader in &mut self.brush_yuv_image {
             if let Some(ref mut shader) = shader {
                 shader.reset();
             }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -1563,12 +1563,12 @@ impl TextureCacheUpdate {
 fn quantize_dimension(size: i32) -> i32 {
     match size {
         0 => unreachable!(),
-        1...16 => 16,
-        17...32 => 32,
-        33...64 => 64,
-        65...128 => 128,
-        129...256 => 256,
-        257...512 => 512,
+        1..=16 => 16,
+        17..=32 => 32,
+        33..=64 => 64,
+        65..=128 => 128,
+        129..=256 => 256,
+        257..=512 => 512,
         _ => panic!("Invalid dimensions for cache!"),
     }
 }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1398,7 +1398,7 @@ pub struct DynamicProperties {
 }
 
 pub trait RenderNotifier: Send {
-    fn clone(&self) -> Box<RenderNotifier>;
+    fn clone(&self) -> Box<dyn RenderNotifier>;
     fn wake_up(&self);
     fn new_frame_ready(&self, DocumentId, scrolled: bool, composite_needed: bool, render_time_ns: Option<u64>);
     fn external_event(&self, _evt: ExternalEvent) {
@@ -1424,12 +1424,12 @@ pub trait NotificationHandler : Send + Sync {
 }
 
 pub struct NotificationRequest {
-    handler: Option<Box<NotificationHandler>>,
+    handler: Option<Box<dyn NotificationHandler>>,
     when: Checkpoint,
 }
 
 impl NotificationRequest {
-    pub fn new(when: Checkpoint, handler: Box<NotificationHandler>) -> Self {
+    pub fn new(when: Checkpoint, handler: Box<dyn NotificationHandler>) -> Self {
         NotificationRequest {
             handler: Some(handler),
             when,

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -305,13 +305,13 @@ pub trait BlobImageResources {
 /// and creating the rasterizer objects, but isn't expected to do any rasterization itself.
 pub trait BlobImageHandler: Send {
     /// Creates a snapshot of the current state of blob images in the handler.
-    fn create_blob_rasterizer(&mut self) -> Box<AsyncBlobImageRasterizer>;
+    fn create_blob_rasterizer(&mut self) -> Box<dyn AsyncBlobImageRasterizer>;
 
     /// A hook to let the blob image handler update any state related to resources that
     /// are not bundled in the blob recording itself.
     fn prepare_resources(
         &mut self,
-        services: &BlobImageResources,
+        services: &dyn BlobImageResources,
         requests: &[BlobImageParams],
     );
 

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -29,7 +29,7 @@ time = "0.1"
 crossbeam = "0.2"
 osmesa-sys = { version = "0.1.2", optional = true }
 osmesa-src = { git = "https://github.com/servo/osmesa-src", optional = true }
-webrender = {path = "../webrender", features=["capture","replay","debugger","png","profiler","serde"]}
+webrender = {path = "../webrender", features=["capture","replay","debugger","png","profiler"]}
 webrender_api = {path = "../webrender_api", features=["serialize","deserialize"]}
 winit = "0.19"
 serde = {version = "1.0", features = ["derive"] }

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -104,7 +104,7 @@ fn render_blob(
 /// See rawtest.rs. We use this to test that blob images are requested the right
 /// amount of times.
 pub struct BlobCallbacks {
-    pub request: Box<Fn(&[BlobImageParams]) + Send + 'static>,
+    pub request: Box<dyn Fn(&[BlobImageParams]) + Send + 'static>,
 }
 
 impl BlobCallbacks {
@@ -151,7 +151,7 @@ impl BlobImageHandler for CheckerboardRenderer {
 
     fn prepare_resources(
         &mut self,
-        _services: &BlobImageResources,
+        _services: &dyn BlobImageResources,
         requests: &[BlobImageParams],
     ) {
         if !requests.is_empty() {
@@ -159,7 +159,7 @@ impl BlobImageHandler for CheckerboardRenderer {
         }
     }
 
-    fn create_blob_rasterizer(&mut self) -> Box<AsyncBlobImageRasterizer> {
+    fn create_blob_rasterizer(&mut self) -> Box<dyn AsyncBlobImageRasterizer> {
         Box::new(Rasterizer { image_cmds: self.image_cmds.clone() })
     }
 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -102,7 +102,7 @@ impl Notifier {
 }
 
 impl RenderNotifier for Notifier {
-    fn clone(&self) -> Box<RenderNotifier> {
+    fn clone(&self) -> Box<dyn RenderNotifier> {
         Box::new(Notifier(self.0.clone()))
     }
 
@@ -184,7 +184,7 @@ impl Wrench {
         disable_dual_source_blending: bool,
         zoom_factor: f32,
         chase_primitive: webrender::ChasePrimitive,
-        notifier: Option<Box<RenderNotifier>>,
+        notifier: Option<Box<dyn RenderNotifier>>,
         init: webrender::DeviceInit<back::Backend>,
     ) -> Self {
         println!("Shader override path: {:?}", shader_override_path);
@@ -192,14 +192,14 @@ impl Wrench {
         let recorder = save_type.map(|save_type| match save_type {
             SaveType::Yaml => Box::new(
                 YamlFrameWriterReceiver::new(&PathBuf::from("yaml_frames")),
-            ) as Box<webrender::ApiRecordingReceiver>,
+            ) as Box<dyn webrender::ApiRecordingReceiver>,
             SaveType::Json => Box::new(JsonFrameWriter::new(&PathBuf::from("json_frames"))) as
-                Box<webrender::ApiRecordingReceiver>,
+                Box<dyn webrender::ApiRecordingReceiver>,
             SaveType::Ron => Box::new(RonFrameWriter::new(&PathBuf::from("ron_frames"))) as
-                Box<webrender::ApiRecordingReceiver>,
+                Box<dyn webrender::ApiRecordingReceiver>,
             SaveType::Binary => Box::new(webrender::BinaryRecorder::new(
                 &PathBuf::from("wr-record.bin"),
-            )) as Box<webrender::ApiRecordingReceiver>,
+            )) as Box<dyn webrender::ApiRecordingReceiver>,
         });
 
         let mut debug_flags = DebugFlags::ECHO_DRIVER_MESSAGES;


### PR DESCRIPTION
These changes make it possible to build the project using the latest Rust nightly (1.37 at the moment).