### PR TITLE
Reduce the number of buffer allocations

### DIFF
--- a/webrender/src/device/gfx/buffer.rs
+++ b/webrender/src/device/gfx/buffer.rs
@@ -75,7 +75,7 @@ impl<B: hal::Backend> Buffer<B> {
         non_coherent_atom_size_mask: u64,
     ) {
         let size = (data.len() * std::mem::size_of::<T>()) as u64;
-        let range = 0 .. ((size + non_coherent_atom_size_mask) & !non_coherent_atom_size_mask);
+        let range = 0 .. ((size + non_coherent_atom_size_mask) & !non_coherent_atom_size_mask).min(self.buffer_size as u64);
         unsafe {
             let mut mapped = self
                 .memory_block

--- a/webrender/src/device/gfx/buffer.rs
+++ b/webrender/src/device/gfx/buffer.rs
@@ -479,7 +479,6 @@ pub(super) struct UniformBufferHandler<B: hal::Backend> {
     buffer_usage: hal::buffer::Usage,
     data_stride: usize,
     pitch_alignment_mask: usize,
-    non_coherent_atom_size_mask: usize,
 }
 
 impl<B: hal::Backend> UniformBufferHandler<B> {
@@ -487,7 +486,6 @@ impl<B: hal::Backend> UniformBufferHandler<B> {
         buffer_usage: hal::buffer::Usage,
         data_stride: usize,
         pitch_alignment_mask: usize,
-        non_coherent_atom_size_mask: usize,
     ) -> Self {
         UniformBufferHandler {
             buffers: vec![],
@@ -495,7 +493,6 @@ impl<B: hal::Backend> UniformBufferHandler<B> {
             buffer_usage,
             data_stride,
             pitch_alignment_mask,
-            non_coherent_atom_size_mask,
         }
     }
 
@@ -511,7 +508,7 @@ impl<B: hal::Backend> UniformBufferHandler<B> {
                 self.data_stride,
             ));
         }
-        self.buffers[self.offset].update_all(device, data, self.non_coherent_atom_size_mask as u64);
+        self.buffers[self.offset].update_all(device, data, self.pitch_alignment_mask as u64);
         self.offset += 1;
     }
 

--- a/webrender/src/device/gfx/buffer.rs
+++ b/webrender/src/device/gfx/buffer.rs
@@ -413,10 +413,10 @@ impl<B: hal::Backend> VertexBufferHandler<B> {
         heaps: &mut Heaps<B>,
         buffer_usage: hal::buffer::Usage,
         data: &[T],
-        data_stride: usize,
         pitch_alignment_mask: usize,
         non_coherent_atom_size_mask: usize,
     ) -> Self {
+        let data_stride = mem::size_of::<T>();
         let mut buffer = Buffer::new(
             device,
             heaps,
@@ -438,6 +438,7 @@ impl<B: hal::Backend> VertexBufferHandler<B> {
     }
 
     pub(super) fn update<T: Copy>(&mut self, device: &B::Device, data: &[T], heaps: &mut Heaps<B>) {
+        self.data_stride = mem::size_of::<T>();
         let buffer_len = data.len() * self.data_stride;
         if self.buffer.buffer_len != buffer_len {
             let old_buffer = mem::replace(

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -494,7 +494,6 @@ impl<B: hal::Backend> Device<B> {
             hal::buffer::Usage::UNIFORM,
             mem::size_of::<Locals>(),
             (limits.min_uniform_buffer_offset_alignment - 1) as usize,
-            (limits.non_coherent_atom_size - 1) as usize,
         );
 
         let quad_buffer = VertexBufferHandler::new(

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -502,7 +502,6 @@ impl<B: hal::Backend> Device<B> {
             &mut heaps,
             hal::buffer::Usage::VERTEX,
             &QUAD,
-            mem::size_of::<vertex_types::Vertex>(),
             (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
             (limits.non_coherent_atom_size - 1) as usize,
         );

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -258,6 +258,8 @@ impl<B: hal::Backend> Device<B> {
         upload_method: UploadMethod,
         _cached_programs: Option<Rc<ProgramCache>>,
         heaps_config: HeapsConfig,
+        instance_buffer_size: usize,
+        texture_cache_size: usize,
     ) -> Self {
         let DeviceInit {
             instance,
@@ -479,10 +481,12 @@ impl<B: hal::Backend> Device<B> {
                 (limits.non_coherent_atom_size - 1) as usize,
                 (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
                 (limits.optimal_buffer_copy_offset_alignment - 1) as usize,
+                texture_cache_size,
             ));
             instance_buffers.push(InstanceBufferHandler::new(
                 (limits.non_coherent_atom_size - 1) as usize,
                 (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
+                instance_buffer_size,
             ));
         }
 

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -12,12 +12,9 @@ use std::borrow::Cow::{Borrowed};
 use super::buffer::{InstanceBufferHandler, VertexBufferHandler};
 use super::blend_state::SUBPIXEL_CONSTANT_TEXT_COLOR;
 use super::render_pass::RenderPass;
-use super::vertex_types;
 use super::PipelineRequirements;
 use super::super::{ShaderKind, VertexArrayKind};
 use super::super::super::shader_source;
-
-use std::mem;
 
 const ENTRY_NAME: &str = "main";
 // The size of the push constant block is 68 bytes, and we upload it with u32 data (4 bytes).

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -20,7 +20,6 @@ use super::super::super::shader_source;
 use std::mem;
 
 const ENTRY_NAME: &str = "main";
-const MAX_INDEX_COUNT: usize = 4096;
 // The size of the push constant block is 68 bytes, and we upload it with u32 data (4 bytes).
 pub(super) const PUSH_CONSTANT_BLOCK_SIZE: usize = 17; // 68 / 4
 // The number of specialization constants in each shader.
@@ -290,11 +289,6 @@ impl<B: hal::Backend> Program<B> {
             states
         };
 
-        let vertex_buffer_stride = match shader_kind {
-            ShaderKind::DebugColor => mem::size_of::<vertex_types::DebugColorVertex>(),
-            ShaderKind::DebugFont => mem::size_of::<vertex_types::DebugFontVertex>(),
-            _ => mem::size_of::<vertex_types::Vertex>(),
-        };
         let (mut vertex_buffer, mut index_buffer) = if shader_kind.is_debug() {
             (Some(SmallVec::new()), Some(SmallVec::new()))
         } else {
@@ -306,8 +300,7 @@ impl<B: hal::Backend> Program<B> {
                     device,
                     heaps,
                     hal::buffer::Usage::VERTEX,
-                    &[0],
-                    vertex_buffer_stride,
+                    &[0u8],
                     (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
                     (limits.non_coherent_atom_size - 1) as usize,
                 ));
@@ -317,8 +310,7 @@ impl<B: hal::Backend> Program<B> {
                     device,
                     heaps,
                     hal::buffer::Usage::INDEX,
-                    &vec![0u32; MAX_INDEX_COUNT],
-                    mem::size_of::<u32>(),
+                    &[0u8],
                     (limits.optimal_buffer_copy_pitch_alignment - 1) as usize,
                     (limits.non_coherent_atom_size - 1) as usize,
                 ));

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1333,6 +1333,10 @@ impl<B: hal::Backend> Renderer<B> {
             options.cached_programs.take(),
             #[cfg(not(feature = "gleam"))]
             options.heaps_config,
+            #[cfg(not(feature = "gleam"))]
+            options.instance_buffer_size,
+            #[cfg(not(feature = "gleam"))]
+            options.texture_cahce_size,
         );
 
         #[cfg(feature = "gleam")]
@@ -4544,6 +4548,10 @@ pub struct RendererOptions {
     pub enable_picture_caching: bool,
     #[cfg(not(feature = "gleam"))]
     pub heaps_config: HeapsConfig,
+    // The size of an instance buffer in bytes
+    pub instance_buffer_size: usize,
+    // The size of a staging buffer for image data upload in bytes
+    pub texture_cahce_size: usize,
 }
 
 impl Default for RendererOptions {
@@ -4585,7 +4593,9 @@ impl Default for RendererOptions {
             heaps_config: HeapsConfig {
                 linear: None,
                 dynamic: None,
-            }
+            },
+            instance_buffer_size: 1 << 20,
+            texture_cahce_size: 16 << 20,
         }
     }
 }


### PR DESCRIPTION
Previously we had vertex and instance buffers for each program, so we had a lot of pending resource if a program was not used frequently. Instead of this we can have one buffer for our main vertices (a quad) for the entire run, and we can store our instance buffers for each frame.
Previously our instance buffers had different sizes and could only store data for one specific data stride. Now we have 1 MB large instance buffers which can store the data of different instances with different data strides.
Also added an optional buffer for data download with a fixed 10 MB size (wrench doesn't require larger than this), so we don't recreate a buffer every time we read the content of the screen.

The two debug program has their vertex and index buffers still attached to their program, since those are not the essential part of rendering, and if we enable them, they are used in every frame. We can refactor them in a later PR as well.