### PR TITLE
Remove typed command buffers, pools and queues

### DIFF
--- a/webrender/src/device/gfx/descriptor.rs
+++ b/webrender/src/device/gfx/descriptor.rs
@@ -5,6 +5,7 @@
 use arrayvec::ArrayVec;
 use hal::Device;
 use hal::pso::{DescriptorSetLayoutBinding, DescriptorType as DT, ShaderStageFlags as SSF};
+use hal::command::RawCommandBuffer;
 use internal_types::FastHashMap;
 use rendy_descriptor::{DescriptorAllocator, DescriptorRanges, DescriptorSet};
 use rendy_memory::Heaps;
@@ -336,7 +337,7 @@ impl<K, B, F> DescriptorSetHandler<K, B, F>
         &mut self,
         bound_textures: &[u32; RENDERER_TEXTURE_COUNT],
         bound_samplers: &[TextureFilter; RENDERER_TEXTURE_COUNT],
-        cmd_buffer: &mut hal::command::CommandBuffer<B, hal::Graphics>,
+        cmd_buffer: &mut B::CommandBuffer,
         bindings: K,
         images: &FastHashMap<TextureId, Image<B>>,
         desc_allocator: &mut DescriptorAllocator<B>,

--- a/webrender/src/device/gfx/image.rs
+++ b/webrender/src/device/gfx/image.rs
@@ -4,6 +4,7 @@
 
 use api::{DeviceIntRect, ImageFormat};
 use hal::{self, Device as BackendDevice};
+use hal::command::{RawCommandBuffer, CommandBufferFlags, CommandBufferInheritanceInfo};
 use rendy_memory::{Block, Heaps, MemoryBlock, MemoryUsageValue};
 
 use std::cell::Cell;
@@ -224,7 +225,8 @@ impl<B: hal::Backend> Image<B> {
         let cmd_buffer = cmd_pool.acquire_command_buffer();
 
         unsafe {
-            cmd_buffer.begin();
+            let flags = CommandBufferFlags::ONE_TIME_SUBMIT;
+            cmd_buffer.begin(flags, CommandBufferInheritanceInfo::default());;
 
             let begin_state = self.core.state.get();
             let mut pre_stage = Some(PipelineStage::COLOR_ATTACHMENT_OUTPUT);


### PR DESCRIPTION
This patch replaces some of the typed elements with their raw form.