### PR TITLE
Move GPU cache updates to the RenderBackend

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -420,6 +420,7 @@ pub fn main_wrapper<E: Example>(
 
         winit::ControlFlow::Continue
     });
+    api.shut_down();
 
     renderer.deinit();
 }

--- a/webrender/src/device/gfx/buffer.rs
+++ b/webrender/src/device/gfx/buffer.rs
@@ -4,51 +4,87 @@
 
 use hal;
 use hal::Device as BackendDevice;
-use rendy_memory::{Block, Heaps, MappedRange, MemoryBlock, MemoryUsageValue, Write};
+use rendy_memory::{Block, Heaps, Kind, MappedRange, MemoryBlock, MemoryUsage, MemoryUsageValue, Write};
 use smallvec::SmallVec;
 
 use std::cell::Cell;
+use std::sync::Arc;
 use std::mem;
 
 pub const DOWNLOAD_BUFFER_SIZE: usize = 10 << 20; // 10MB
 
-pub(crate) struct PMBuffer<B: hal::Backend> {
-    pub buffer: B::Buffer,
-    pub memory_block: MemoryBlock<B>,
-    pub coherent: bool,
-    pub height: u64,
-    pub size: u64,
-    pub state: Cell<hal::buffer::State>,
-    pub non_coherent_atom_size_mask: u64,
-    pub transit_range_end: u64,
+#[derive(MallocSizeOf)]
+pub struct BufferMemorySlice {
+    #[ignore_malloc_size_of = "ptr"]
+    ptr: *mut u8,
+    size: usize,
 }
 
-impl<B: hal::Backend> PMBuffer<B> {
-    pub(super) fn map<'a>(&'a mut self, device: &B::Device, size: Option<u64>) -> (MappedRange<'a, B>, u64) {
-        assert!(size.unwrap_or(0) <= self.size);
-        let size = size.unwrap_or(self.size);
-        (self.memory_block.map(&device, 0..size).expect("Mapping memory block failed"), size)
-    }
+unsafe impl Send for BufferMemorySlice {}
+unsafe impl Sync for BufferMemorySlice {}
 
-    pub(super) fn unmap(&mut self, device: &B::Device) {
-        self.memory_block.unmap(device);
-    }
-
-    pub(super) unsafe fn update_transit_range(
-        &mut self,
-        address_max: u64,
-    ) {
-        self.transit_range_end = self.transit_range_end.max(address_max);
-    }
-
-    pub(super) fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
-        unsafe {
-            device.destroy_buffer(self.buffer);
-            heaps.free(device, self.memory_block);
+impl BufferMemorySlice {
+    pub fn new(ptr: *mut u8, size: usize) -> Self {
+        BufferMemorySlice {
+            ptr,
+            size
         }
     }
 
-    pub(super) fn transit(&self, access: hal::buffer::Access, with_range: bool) -> Option<hal::memory::Barrier<B>> {
+    pub(crate) fn slice_mut<T>(&mut self) -> &mut [T] {
+        use std::slice;
+        let size_of_t = mem::size_of::<T>();
+        assert_eq!(self.ptr as usize % size_of_t, 0);
+        assert_eq!(self.size % size_of_t, 0);
+        unsafe { slice::from_raw_parts_mut(self.ptr as _, self.size / size_of_t) }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PMBufferMemoryUsage;
+impl MemoryUsage for PMBufferMemoryUsage {
+    fn properties_required(&self) -> hal::memory::Properties {
+        hal::memory::Properties::CPU_VISIBLE
+    }
+
+    #[inline]
+    fn memory_fitness(&self, properties: hal::memory::Properties) -> u32 {
+        assert!(properties.contains(hal::memory::Properties::CPU_VISIBLE));
+        assert!(!properties.contains(hal::memory::Properties::LAZILY_ALLOCATED));
+
+        0 | (properties.contains(hal::memory::Properties::CPU_CACHED) as u32) << 2
+            | (properties.contains(hal::memory::Properties::COHERENT) as u32) << 1
+    }
+
+    fn allocator_fitness(&self, kind: Kind) -> u32 {
+        match kind {
+            Kind::Dedicated => 2,
+            Kind::Dynamic => 1,
+            Kind::Linear => 0,
+        }
+    }
+}
+
+#[derive(MallocSizeOf)]
+pub struct GpuCacheBuffer<B: hal::Backend> {
+    #[ignore_malloc_size_of = "handle"]
+    pub buffer: Arc<B::Buffer>,
+    pub transit_range_end: u64,
+    #[ignore_malloc_size_of = "State does not implement size_of"]
+    pub state: Cell<hal::buffer::State>,
+}
+
+unsafe impl<B: hal::Backend> Send for GpuCacheBuffer<B> {}
+unsafe impl<B: hal::Backend> Sync for GpuCacheBuffer<B> {}
+
+impl<B: hal::Backend> GpuCacheBuffer<B> {
+    pub fn update_transit_range(&mut self, range_end: u64) {
+        if range_end > self.transit_range_end {
+            self.transit_range_end = range_end;
+        }
+    }
+
+    pub fn transit(&self, access: hal::buffer::Access, with_range: bool) -> Option<hal::memory::Barrier<B>> {
         let src_state = self.state.get();
         if src_state == access {
             None
@@ -60,6 +96,128 @@ impl<B: hal::Backend> PMBuffer<B> {
                 families: None,
                 range: None .. if with_range { Some(self.transit_range_end) } else { None },
             })
+        }
+    }
+}
+
+#[derive(Debug)]
+#[derive(MallocSizeOf)]
+pub struct PersistentlyMappedBuffer<B: hal::Backend> {
+    #[ignore_malloc_size_of = "buffer handle"]
+    pub buffer: Arc<B::Buffer>,
+    #[ignore_malloc_size_of = "memory handle"]
+    pub memory_block: MemoryBlock<B>,
+    pub coherent: bool,
+    pub height: u64,
+    pub size: u64,
+    pub non_coherent_atom_size_mask: u64,
+}
+
+unsafe impl<B: hal::Backend> Send for PersistentlyMappedBuffer<B> {}
+unsafe impl<B: hal::Backend> Sync for PersistentlyMappedBuffer<B> {}
+
+impl<B: hal::Backend> PersistentlyMappedBuffer<B> {
+    pub(crate) fn new<T>(
+        device: &B::Device,
+        heaps: &mut Heaps<B>,
+        non_coherent_atom_size_mask: u64,
+        width: u64,
+        height: u64,
+        copy_src: Option<&mut PersistentlyMappedBuffer<B>>,
+    ) -> Self {
+        let buffer_stride = std::mem::size_of::<T>() as u64;
+        let buffer_len = height * width * buffer_stride;
+
+        assert_ne!(buffer_len, 0);
+        let mut storage_buffer =
+            unsafe { device.create_buffer(buffer_len, hal::buffer::Usage::STORAGE) }.unwrap();
+
+        let buffer_req = unsafe { device.get_buffer_requirements(&storage_buffer) };
+        //let alignment = ((buffer_req.alignment - 1) | non_coherent_atom_size_mask) +1;
+        let alignment = buffer_req.alignment;
+        let memory_block = heaps
+            .allocate(
+                device,
+                buffer_req.type_mask as u32,
+                PMBufferMemoryUsage,
+                buffer_req.size,
+                alignment,
+            )
+            .expect("Allocate memory failed");
+
+        assert!(memory_block.properties().contains(hal::memory::Properties::CPU_CACHED));
+        let coherent = memory_block.properties().contains(hal::memory::Properties::COHERENT);
+
+        unsafe {
+            device.bind_buffer_memory(
+                &memory_block.memory(),
+                memory_block.range().start,
+                &mut storage_buffer,
+            )
+        }
+        .expect("Bind buffer memory failed");
+        let mut buffer = PersistentlyMappedBuffer {
+            buffer: Arc::new(storage_buffer),
+            memory_block,
+            coherent,
+            height,
+            size: buffer_req.size,
+            non_coherent_atom_size_mask,
+        };
+
+        if let Some(src) = copy_src {
+            unsafe { buffer.copy_from(src, device) };
+        }
+
+        buffer
+    }
+
+    unsafe fn copy_from(&mut self, copy_src: &mut Self, device: &B::Device) {
+        {
+            let (mut mapped, read_size) = copy_src.map(device, None);
+            let read_slice = mapped.read::<u8>(device, 0..read_size).unwrap();
+            let (mut mapped, _) = self.map(device, Some(read_size));
+            let mut writer = mapped.write::<u8>(device, 0..read_size).unwrap();
+            let writer_slice = writer.slice();
+            writer_slice.copy_from_slice(read_slice);
+        }
+        copy_src.unmap(device);
+        self.unmap(device);
+    }
+
+    pub fn buffer_memory_slice(
+        &mut self,
+        device: &B::Device,
+    ) -> BufferMemorySlice {
+        let (mapped, size) = self.map(device, None);
+        BufferMemorySlice::new(
+            mapped.ptr().as_ptr(),
+            size as usize,
+        )
+    }
+
+    pub fn map<'a>(&'a mut self, device: &B::Device, size: Option<u64>) -> (MappedRange<'a, B>, u64) {
+        assert!(size.unwrap_or(0) <= self.size, "size {:?} <= self.size {:?}", size.unwrap_or(0), self.size);
+        let size = size.unwrap_or(self.size);
+        (self.memory_block.map(&device, 0..size).expect("Mapping memory block failed"), size)
+    }
+
+    pub fn unmap(&mut self, device: &B::Device) {
+        self.memory_block.unmap(device);
+    }
+
+    pub fn deinit(self, device: &B::Device, heaps: &mut Heaps<B>) {
+        unsafe {
+            device.destroy_buffer(Arc::try_unwrap(self.buffer).unwrap());
+            heaps.free(device, self.memory_block);
+        }
+    }
+
+    pub fn get_buffer_info(&self, transit_range_end: u64) -> GpuCacheBuffer<B> {
+        GpuCacheBuffer {
+            buffer: Arc::clone(&self.buffer),
+            transit_range_end: transit_range_end,
+            state: Cell::new(hal::buffer::Access::empty()),
         }
     }
 }

--- a/webrender/src/device/gfx/descriptor.rs
+++ b/webrender/src/device/gfx/descriptor.rs
@@ -15,7 +15,7 @@ use std::cmp::Eq;
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 use std::marker::Copy;
-use super::buffer::{UniformBufferHandler, PMBuffer};
+use super::buffer::UniformBufferHandler;
 use super::image::Image;
 use super::TextureId;
 use super::super::{ShaderKind, TextureFilter, VertexArrayKind};
@@ -341,7 +341,7 @@ impl<K, B, F> DescriptorSetHandler<K, B, F>
         cmd_buffer: &mut B::CommandBuffer,
         bindings: K,
         images: &FastHashMap<TextureId, Image<B>>,
-        storage_buffer: Option<&PMBuffer<B>>,
+        storage_buffer: Option<&B::Buffer>,
         desc_allocator: &mut DescriptorAllocator<B>,
         device: &B::Device,
         group_data: &DescriptorData<B>,
@@ -381,7 +381,7 @@ impl<K, B, F> DescriptorSetHandler<K, B, F>
                     binding: GPU_CACHE_BINDING,
                     array_offset: 0,
                     descriptors: Some(hal::pso::Descriptor::Buffer(
-                        &buffer.buffer,
+                        buffer,
                         None .. None,
                     )),
                 });

--- a/webrender/src/device/gfx/mod.rs
+++ b/webrender/src/device/gfx/mod.rs
@@ -13,6 +13,7 @@ mod render_pass;
 pub(crate) mod vertex_types;
 
 pub use self::device::*;
+pub use self::buffer::{BufferMemorySlice, GpuCacheBuffer, PersistentlyMappedBuffer};
 
 use gpu_types;
 use hal;

--- a/webrender/src/device/mod.rs
+++ b/webrender/src/device/mod.rs
@@ -347,6 +347,10 @@ pub struct Texture {
 }
 
 impl Texture {
+    pub fn id(&self) -> IdType {
+        self.id
+    }
+
     pub fn get_dimensions(&self) -> DeviceIntSize {
         self.size
     }

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -25,11 +25,17 @@
 //! for this frame.
 
 use api::{DebugFlags, DocumentId, PremultipliedColorF, IdNamespace, TexelRect};
+#[cfg(not(feature="gleam"))]
+use device::{BufferMemorySlice, GpuCacheBuffer, PersistentlyMappedBuffer};
 use euclid::TypedRect;
+#[cfg(not(feature="gleam"))]
+use hal;
 use internal_types::{FastHashMap};
 use profiler::GpuCacheProfileCounters;
 use render_backend::{FrameStamp, FrameId};
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+#[cfg(not(feature="gleam"))]
+use rendy_memory::Write;
 use std::{mem, u16, u32};
 use std::num::NonZeroU32;
 use std::ops::Add;
@@ -324,6 +330,45 @@ pub struct GpuCacheUpdateList {
     /// Whole state GPU block metadata for debugging.
     #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     pub debug_commands: Vec<GpuCacheDebugCmd>,
+}
+
+#[cfg(not(feature="gleam"))]
+#[cfg_attr(any(feature = "capture", feature = "serialize_program"), derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[derive(MallocSizeOf)]
+pub struct GpuCacheBufferUpdate<B: hal::Backend> {
+    /// The frame current update list was generated from.
+    pub frame_id: FrameId,
+    /// If a new GPU cache buffer is created Renderer needs to know about this.
+    #[cfg_attr(any(feature = "capture", feature = "replay", feature = "serialize_program"), serde(skip))]
+    pub buffer_update: BufferInfo<B>,
+    /// Whole state GPU block metadata for debugging.
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
+    pub debug_commands: Vec<GpuCacheDebugCmd>,
+}
+
+#[cfg(not(feature="gleam"))]
+#[derive(MallocSizeOf)]
+pub enum BufferInfo<B: hal::Backend> {
+    BufferUpdate {
+        /// A view into the current GPU cache buffer's memory on the CPU side,
+        /// to write out deferred resolves in the Renderer thread.
+        buffer_memory_slice: BufferMemorySlice,
+        /// The handle of the new buffer,
+        /// this is needed for creating descriptor sets in the Renderer thread.
+        new_buffer_info: GpuCacheBuffer<B>,
+        /// The old buffer. We keep this alive in the Renderer thread
+        /// until it's underlying buffer handle is bound to a frame.
+        old_buffer: Option<PersistentlyMappedBuffer<B>>,
+    },
+    TransitRangeUpdate(u64),
+}
+
+#[cfg(not(feature="gleam"))]
+impl<B: hal::Backend> std::default::Default for BufferInfo<B> {
+    fn default() -> Self {
+        BufferInfo::TransitRangeUpdate(0)
+    }
 }
 
 // Holds the free lists of fixed size blocks. Mostly
@@ -663,7 +708,6 @@ impl<'a> Drop for GpuDataRequest<'a> {
     }
 }
 
-
 /// The main LRU cache interface.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -680,7 +724,7 @@ pub struct GpuCache {
     debug_flags: DebugFlags,
     /// Whether there is a pending clear to send with the
     /// next update.
-    pending_clear: bool,
+    pub(crate) pending_clear: bool,
 }
 
 impl GpuCache {
@@ -693,6 +737,11 @@ impl GpuCache {
             debug_flags,
             pending_clear: false,
         }
+    }
+
+    #[cfg(not(feature="gleam"))]
+    pub fn height(&self) -> u64 {
+        self.texture.height as u64
     }
 
     /// Creates a GpuCache and sets it up with a valid `FrameStamp`, which
@@ -831,6 +880,7 @@ impl GpuCache {
     }
 
     /// Extract the pending updates from the cache.
+    #[cfg(feature="gleam")]
     pub fn extract_updates(&mut self) -> GpuCacheUpdateList {
         let clear = self.pending_clear;
         self.pending_clear = false;
@@ -841,6 +891,56 @@ impl GpuCache {
             debug_commands: mem::replace(&mut self.texture.debug_commands, Vec::new()),
             updates: mem::replace(&mut self.texture.updates, Vec::new()),
             blocks: mem::replace(&mut self.texture.pending_blocks, Vec::new()),
+        }
+    }
+
+    #[cfg(not(feature="gleam"))]
+    pub fn write_updates<B: hal::Backend>(
+        &mut self,
+        buffer: &mut PersistentlyMappedBuffer<B>,
+        device: &B::Device,
+        old_buffer: Option<PersistentlyMappedBuffer<B>>,
+        send_buffer: bool,
+    ) -> GpuCacheBufferUpdate<B> {
+        let mut address_max = 0;
+        {
+            let (mut mapped_range, size) = buffer.map(device, None);
+            let mut writer = unsafe {
+                    mapped_range.write::<GpuBlockData>(
+                    device,
+                    0..(size / mem::size_of::<GpuBlockData>() as u64)
+                )
+            }.unwrap();
+            let writer_slice = unsafe { writer.slice() };
+
+            let blocks = mem::replace(&mut self.texture.pending_blocks, Vec::new());
+            for update in mem::replace(&mut self.texture.updates, Vec::new()) {
+                match update {
+                    GpuCacheUpdate::Copy {
+                        block_index,
+                        block_count,
+                        address,
+                    } => {
+                        let address = address.v as usize * MAX_VERTEX_TEXTURE_WIDTH + address.u as usize;
+                        address_max = address_max.max((address + block_count) as u64 * GpuBlockData::SIZE);
+                        writer_slice[address .. address + block_count]
+                            .copy_from_slice(&blocks[block_index .. block_index + block_count]);
+                    }
+                }
+            }
+        }
+        GpuCacheBufferUpdate {
+            frame_id: self.now.frame_id(),
+            buffer_update: if send_buffer {
+                BufferInfo::BufferUpdate {
+                    buffer_memory_slice: buffer.buffer_memory_slice(device),
+                    new_buffer_info: buffer.get_buffer_info(address_max),
+                    old_buffer,
+                }
+            } else {
+                BufferInfo::TransitRangeUpdate(address_max)
+            },
+            debug_commands: mem::replace(&mut self.texture.debug_commands, Vec::new()),
         }
     }
 

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -7,7 +7,10 @@ use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use api::{ImageFormat, WorldPixel, NotificationRequest};
 use device::TextureFilter;
 use renderer::PipelineInfo;
+#[cfg(not(feature="gleam"))]
+use gpu_cache::GpuCacheBufferUpdate;
 use gpu_cache::GpuCacheUpdateList;
+use hal;
 use fxhash::FxHasher;
 use plane_split::BspSplitter;
 use profiler::BackendProfileCounters;
@@ -299,11 +302,15 @@ pub enum DebugOutput {
 }
 
 #[allow(dead_code)]
-pub enum ResultMsg {
+pub enum ResultMsg<B: hal::Backend> {
     DebugCommand(DebugCommand),
     DebugOutput(DebugOutput),
     RefreshShader(PathBuf),
     UpdateGpuCache(GpuCacheUpdateList),
+    #[cfg(not(feature="gleam"))]
+    UpdateGpuCacheBuffer(GpuCacheBufferUpdate<B>),
+    #[cfg(feature="gleam")]
+    Phantom(std::marker::PhantomData<B>),
     UpdateResources {
         updates: TextureUpdateList,
         memory_pressure: bool,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -25,8 +25,13 @@ use api::CapturedDocument;
 use clip_scroll_tree::{SpatialNodeIndex, ClipScrollTree};
 #[cfg(feature = "debugger")]
 use debug_server;
+#[cfg(not(feature="gleam"))]
+use device::PersistentlyMappedBuffer;
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use gpu_cache::GpuCache;
+#[cfg(not(feature="gleam"))]
+use gpu_cache::{GpuBlockData, GPU_CACHE_INITIAL_HEIGHT};
+use hal;
 use hit_test::{HitTest, HitTester};
 use intern_types;
 use internal_types::{DebugOutput, FastHashMap, FastHashSet, RenderedDocument, ResultMsg};
@@ -37,6 +42,10 @@ use prim_store::{PrimitiveInstanceKind, PrimTemplateCommonData};
 use profiler::{BackendProfileCounters, IpcProfileCounters, ResourceProfileCounters};
 use record::ApiRecordingReceiver;
 use renderer::{AsyncPropertySampler, PipelineInfo};
+#[cfg(not(feature="gleam"))]
+use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+#[cfg(not(feature="gleam"))]
+use rendy_memory::Heaps;
 use resource_cache::ResourceCache;
 #[cfg(feature = "replay")]
 use resource_cache::PlainCacheOwn;
@@ -52,6 +61,8 @@ use serde_json;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::mem::replace;
+#[cfg(not(feature="gleam"))]
+use std::sync::{Arc, Mutex, Weak};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::time::{UNIX_EPOCH, SystemTime};
 use std::u32;
@@ -661,10 +672,19 @@ struct PlainRenderBackend {
 /// GPU-friendly work which is then submitted to the renderer in the form of a frame::Frame.
 ///
 /// The render backend operates on its own thread.
-pub struct RenderBackend {
+pub struct RenderBackend<B: hal::Backend> {
+    #[cfg(not(feature="gleam"))]
+    device: Arc<B::Device>,
+    #[cfg(not(feature="gleam"))]
+    heaps: Weak<Mutex<Heaps<B>>>,
+    #[cfg(not(feature="gleam"))]
+    gpu_cache_buffer: PersistentlyMappedBuffer<B>,
+    #[cfg(not(feature="gleam"))]
+    send_buffer_handle_to_renderer: bool,
+
     api_rx: MsgReceiver<ApiMsg>,
     payload_rx: Receiver<Payload>,
-    result_tx: Sender<ResultMsg>,
+    result_tx: Sender<ResultMsg<B>>,
     scene_tx: Sender<SceneBuilderRequest>,
     low_priority_scene_tx: Sender<SceneBuilderRequest>,
     scene_rx: Receiver<SceneBuilderResult>,
@@ -689,11 +709,12 @@ pub struct RenderBackend {
     recycler: Recycler,
 }
 
-impl RenderBackend {
+impl<B: hal::Backend> RenderBackend<B> {
+    #[cfg(not(feature="gleam"))]
     pub fn new(
         api_rx: MsgReceiver<ApiMsg>,
         payload_rx: Receiver<Payload>,
-        result_tx: Sender<ResultMsg>,
+        result_tx: Sender<ResultMsg<B>>,
         scene_tx: Sender<SceneBuilderRequest>,
         low_priority_scene_tx: Sender<SceneBuilderRequest>,
         scene_rx: Receiver<SceneBuilderResult>,
@@ -706,7 +727,64 @@ impl RenderBackend {
         size_of_ops: Option<MallocSizeOfOps>,
         debug_flags: DebugFlags,
         namespace_alloc_by_client: bool,
-    ) -> RenderBackend {
+        device: Arc<B::Device>,
+        heaps: Weak<Mutex<Heaps<B>>>,
+        non_coherent_atom_size_mask: u64,
+    ) -> RenderBackend<B> {
+        let heaps_strong = heaps.upgrade().unwrap();
+        let gpu_cache_buffer = PersistentlyMappedBuffer::new::<GpuBlockData>(
+            device.as_ref(),
+            &mut heaps_strong.lock().unwrap(),
+            non_coherent_atom_size_mask,
+            MAX_VERTEX_TEXTURE_WIDTH as _,
+            GPU_CACHE_INITIAL_HEIGHT as _,
+            None,
+        );
+        RenderBackend {
+            device,
+            heaps,
+            gpu_cache_buffer,
+            send_buffer_handle_to_renderer: true,
+            api_rx,
+            payload_rx,
+            result_tx,
+            scene_tx,
+            low_priority_scene_tx,
+            scene_rx,
+            payload_buffer: Vec::new(),
+            default_device_pixel_ratio,
+            resource_cache,
+            gpu_cache: GpuCache::new(),
+            frame_config,
+            documents: FastHashMap::default(),
+            notifier,
+            recorder,
+            sampler,
+            size_of_ops,
+            debug_flags,
+            namespace_alloc_by_client,
+            recycler: Recycler::new(),
+        }
+    }
+
+    #[cfg(feature="gleam")]
+    pub fn new(
+        api_rx: MsgReceiver<ApiMsg>,
+        payload_rx: Receiver<Payload>,
+        result_tx: Sender<ResultMsg<B>>,
+        scene_tx: Sender<SceneBuilderRequest>,
+        low_priority_scene_tx: Sender<SceneBuilderRequest>,
+        scene_rx: Receiver<SceneBuilderResult>,
+        default_device_pixel_ratio: f32,
+        resource_cache: ResourceCache,
+        notifier: Box<dyn RenderNotifier>,
+        frame_config: FrameBuilderConfig,
+        recorder: Option<Box<dyn ApiRecordingReceiver>>,
+        sampler: Option<Box<dyn AsyncPropertySampler + Send>>,
+        size_of_ops: Option<MallocSizeOfOps>,
+        debug_flags: DebugFlags,
+        namespace_alloc_by_client: bool,
+    ) -> RenderBackend<B> {
         RenderBackend {
             api_rx,
             payload_rx,
@@ -727,6 +805,13 @@ impl RenderBackend {
             debug_flags,
             namespace_alloc_by_client,
             recycler: Recycler::new(),
+        }
+    }
+
+    pub fn deinit(self) {
+        #[cfg(not(feature="gleam"))] {
+            let heaps_strong = self.heaps.upgrade().unwrap();
+            heaps_strong.lock().unwrap().free(self.device.as_ref(), self.gpu_cache_buffer.memory_block);
         }
     }
 
@@ -1372,7 +1457,48 @@ impl RenderBackend {
                 debug!("generated frame for document {:?} with {} passes",
                     document_id, rendered_document.frame.passes.len());
 
+                #[cfg(feature="gleam")]
                 let msg = ResultMsg::UpdateGpuCache(self.gpu_cache.extract_updates());
+
+                #[cfg(not(feature="gleam"))]
+                let msg = {
+                    let clear = self.gpu_cache.pending_clear;
+                    let resize = self.gpu_cache.height() > self.gpu_cache_buffer.height;
+                    let old_buffer = if clear || resize {
+                        let heaps_strong = self.heaps.upgrade().unwrap();
+                        let new_buffer = PersistentlyMappedBuffer::new::<GpuBlockData>(
+                            self.device.as_ref(),
+                            &mut heaps_strong.lock().unwrap(),
+                            self.gpu_cache_buffer.non_coherent_atom_size_mask,
+                            MAX_VERTEX_TEXTURE_WIDTH as _,
+                            self.gpu_cache.height(),
+                            if resize {
+                                Some(&mut self.gpu_cache_buffer)
+                            } else {
+                                None
+                            },
+                        );
+
+                        let old_buffer = replace(&mut self.gpu_cache_buffer, new_buffer);
+                        self.send_buffer_handle_to_renderer = true;
+                        if clear {
+                            self.gpu_cache.pending_clear = false;
+                        }
+                        Some(old_buffer)
+                    } else {
+                        None
+                    };
+
+                    let msg = ResultMsg::UpdateGpuCacheBuffer(self.gpu_cache.write_updates(
+                        &mut self.gpu_cache_buffer,
+                        self.device.as_ref(),
+                        old_buffer,
+                        self.send_buffer_handle_to_renderer,
+                    ));
+
+                    self.send_buffer_handle_to_renderer = false;
+                    msg
+                };
                 self.result_tx.send(msg).unwrap();
 
                 frame_build_time = Some(precise_time_ns() - frame_build_start_time);
@@ -1427,6 +1553,36 @@ impl RenderBackend {
 
         if !doc.hit_tester_is_valid {
             doc.rebuild_hit_tester();
+        }
+    }
+
+    #[cfg(all(not(feature = "gleam"), any(feature = "capture", feature = "replay")))]
+    fn ensure_buffer(&mut self) -> Option<PersistentlyMappedBuffer<B>> {
+        let clear = self.gpu_cache.pending_clear;
+        let resize = self.gpu_cache.height() > self.gpu_cache_buffer.height;
+        if clear || resize {
+            let heaps_strong = self.heaps.upgrade().unwrap();
+            let new_buffer = PersistentlyMappedBuffer::new::<GpuBlockData>(
+                self.device.as_ref(),
+                &mut heaps_strong.lock().unwrap(),
+                self.gpu_cache_buffer.non_coherent_atom_size_mask,
+                MAX_VERTEX_TEXTURE_WIDTH as _,
+                self.gpu_cache.height(),
+                if resize {
+                    Some(&mut self.gpu_cache_buffer)
+                } else {
+                    None
+                },
+            );
+
+            let old_buffer = replace(&mut self.gpu_cache_buffer, new_buffer);
+            self.send_buffer_handle_to_renderer = true;
+            if clear {
+                self.gpu_cache.pending_clear = false;
+            }
+            Some(old_buffer)
+        } else {
+            None
         }
     }
 
@@ -1595,7 +1751,7 @@ impl ToDebugString for SpecificDisplayItem {
     }
 }
 
-impl RenderBackend {
+impl<B: hal::Backend> RenderBackend<B> {
     #[cfg(feature = "capture")]
     // Note: the mutable `self` is only needed here for resolving blob images
     fn save_capture(
@@ -1664,7 +1820,21 @@ impl RenderBackend {
             // After we rendered the frames, there are pending updates to both
             // GPU cache and resources. Instead of serializing them, we are going to make sure
             // they are applied on the `Renderer` side.
+
+            #[cfg(feature="gleam")]
             let msg_update_gpu_cache = ResultMsg::UpdateGpuCache(self.gpu_cache.extract_updates());
+            #[cfg(not(feature="gleam"))]
+            let msg_update_gpu_cache = {
+                let old_buffer = self.ensure_buffer();
+                let msg = ResultMsg::UpdateGpuCacheBuffer(self.gpu_cache.write_updates(
+                    &mut self.gpu_cache_buffer,
+                    self.device.as_ref(),
+                    old_buffer,
+                    self.send_buffer_handle_to_renderer,
+                ));
+                self.send_buffer_handle_to_renderer = false;
+                msg
+            };
             self.result_tx.send(msg_update_gpu_cache).unwrap();
             let msg_update_resources = ResultMsg::UpdateResources {
                 updates: self.resource_cache.pending_updates(),
@@ -1754,7 +1924,20 @@ impl RenderBackend {
                 Some(frame) => {
                     info!("\tloaded a built frame with {} passes", frame.passes.len());
 
+                    #[cfg(feature="gleam")]
                     let msg_update = ResultMsg::UpdateGpuCache(self.gpu_cache.extract_updates());
+                    #[cfg(not(feature="gleam"))]
+                    let msg_update = {
+                        let old_buffer = self.ensure_buffer();
+                        let msg = ResultMsg::UpdateGpuCacheBuffer(self.gpu_cache.write_updates(
+                            &mut self.gpu_cache_buffer,
+                            self.device.as_ref(),
+                            old_buffer,
+                            self.send_buffer_handle_to_renderer,
+                        ));
+                        self.send_buffer_handle_to_renderer = false;
+                        msg
+                    };
                     self.result_tx.send(msg_update).unwrap();
 
                     let msg_publish = ResultMsg::PublishDocument(

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -48,14 +48,18 @@ use device::{ProgramCache, ReadPixelsFormat};
 use device::query::GpuTimer;
 #[cfg(feature = "gleam")]
 use device::{CustomVAO, Program, VBO};
+#[cfg(not(feature="gleam"))]
+use device::BufferMemorySlice;
 use euclid::rect;
 use euclid::Transform3D;
 use frame_builder::{ChasePrimitive, FrameBuilderConfig};
 #[cfg(feature = "gleam")]
 use gleam::gl;
 use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
-use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
-use gpu_cache::{GpuCacheDebugChunk, GpuCacheDebugCmd};
+#[cfg(not(feature="gleam"))]
+use gpu_cache::BufferInfo;
+use gpu_cache::{GpuBlockData, GpuCacheUpdate};
+use gpu_cache::{GpuCacheUpdateList, GpuCacheDebugChunk, GpuCacheDebugCmd};
 #[cfg(feature = "pathfinder")]
 use gpu_glyph_renderer::GpuGlyphRenderer;
 use gpu_types::ScalingInstance;
@@ -701,7 +705,9 @@ impl CacheRow {
 enum GpuCacheBus {
     /// Persistently mapped buffer-based updates
     #[cfg(not(feature = "gleam"))]
-    PMbuffer,
+    PersistentlyMappedBuffer {
+        slice: Option<BufferMemorySlice>,
+    },
     /// PBO-based updates, currently operate on a row granularity.
     /// Therefore, are subject to fragmentation issues.
     PixelBuffer {
@@ -757,40 +763,31 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
 
         #[cfg(not(feature = "gleam"))]
         {
-            let texture = device.create_gpu_cache_texture(
-                new_size.width,
-                new_size.height,
-            );
-
-            // Blit the contents of the previous texture, if applicable.
-            if let Some(blit_source) = blit_source {
-                device.copy_cache_buffer(&texture, &blit_source);
-                device.retain_cache_buffer(blit_source);
+            if let GpuCacheBus::PersistentlyMappedBuffer { .. } = self.bus {
+                let texture = device.create_dummy_gpu_cache_texture();
+                self.texture = Some(texture);
+                return
             }
-            self.texture = Some(texture);
         }
 
-        #[cfg(feature = "gleam")]
-        {
-            let rt_info = Some(RenderTargetInfo { has_depth: false });
-            let mut texture = device.create_texture(
-                TextureTarget::Default,
-                ImageFormat::RGBAF32,
-                new_size.width,
-                new_size.height,
-                TextureFilter::Nearest,
-                rt_info,
-                1,
-            );
+        let rt_info = Some(RenderTargetInfo { has_depth: false });
+        let mut texture = device.create_texture(
+            TextureTarget::Default,
+            ImageFormat::RGBAF32,
+            new_size.width,
+            new_size.height,
+            TextureFilter::Nearest,
+            rt_info,
+            1,
+        );
 
-            // Blit the contents of the previous texture, if applicable.
-            if let Some(blit_source) = blit_source {
-                device.blit_renderable_texture(&mut texture, &blit_source);
-                device.delete_texture(blit_source);
-            }
-
-            self.texture = Some(texture);
+        // Blit the contents of the previous texture, if applicable.
+        if let Some(blit_source) = blit_source {
+            device.blit_renderable_texture(&mut texture, &blit_source);
+            device.delete_texture(blit_source);
         }
+
+        self.texture = Some(texture);
     }
 
     fn new(device: &mut Device<B>, use_scatter: bool, _use_pmb: bool) -> Result<Self, RendererError> {
@@ -832,7 +829,13 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
         #[cfg(not(feature = "gleam"))]
         {
             if _use_pmb {
-                bus = GpuCacheBus::PMbuffer;
+                bus = GpuCacheBus::PersistentlyMappedBuffer { slice: None };
+                let texture = device.create_dummy_gpu_cache_texture();
+                return Ok(GpuCacheTexture {
+                    texture: Some(texture),
+                    bus,
+                    phantom_data: PhantomData,
+                })
             } else {
                 let buffer = device.create_pbo();
                 bus = GpuCacheBus::PixelBuffer {
@@ -852,9 +855,9 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
     fn deinit(mut self, device: &mut Device<B>) {
         match self.bus {
             #[cfg(not(feature = "gleam"))]
-            GpuCacheBus::PMbuffer { .. } => {
+            GpuCacheBus::PersistentlyMappedBuffer { .. } => {
                 if let Some(t) = self.texture.take() {
-                    device.retain_cache_buffer(t);
+                    device.delete_texture(t);
                 }
             }
             GpuCacheBus::PixelBuffer { buffer, ..} => {
@@ -889,7 +892,7 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
         self.ensure_texture(device, max_height);
         match self.bus {
             #[cfg(not(feature = "gleam"))]
-            GpuCacheBus::PMbuffer { .. } => {},
+            GpuCacheBus::PersistentlyMappedBuffer { .. } => {},
             GpuCacheBus::PixelBuffer { .. } => {},
             #[cfg(feature = "gleam")]
             GpuCacheBus::Scatter {
@@ -907,41 +910,25 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
         }
     }
 
-    fn update(&mut self, device: &mut Device<B>, updates: &GpuCacheUpdateList) {
+    fn update(&mut self, _device: &mut Device<B>, updates: &GpuCacheUpdateList) {
         match self.bus {
             #[cfg(not(feature = "gleam"))]
-            GpuCacheBus::PMbuffer => {
-                use rendy_memory::Write;
-                let mut address_max = 0;
-                unsafe {
-                    let (mut mapped_range, size) =
-                        Device::map_gpu_cache_memory(
-                            &mut device.gpu_cache_buffers,
-                            device.bound_gpu_cache,
-                            &device.device,
-                        );
-                    let mut writer = mapped_range.write::<GpuBlockData>(
-                        &device.device,
-                        0..(size / mem::size_of::<GpuBlockData>() as u64)
-                    ).unwrap();
-                    let writer_slice = writer.slice();
-                    for update in &updates.updates {
-                        match *update {
-                            GpuCacheUpdate::Copy {
-                                block_index,
-                                block_count,
-                                address,
-                            } => {
-                                let address = address.v as usize * MAX_VERTEX_TEXTURE_WIDTH + address.u as usize;
-                                address_max = address_max.max((address + block_count) as u64 * GpuBlockData::SIZE);
-                                for i in 0 .. block_count {
-                                    writer_slice[address + i] = updates.blocks[block_index + i];
-                                }
-                            }
+            GpuCacheBus::PersistentlyMappedBuffer { ref mut slice } => {
+                let slice = slice.as_mut().unwrap();
+                let writer_slice = slice.slice_mut::<GpuBlockData>();
+                for update in &updates.updates {
+                    match *update {
+                        GpuCacheUpdate::Copy {
+                            block_index,
+                            block_count,
+                            address,
+                        } => {
+                            let address = address.v as usize * MAX_VERTEX_TEXTURE_WIDTH + address.u as usize;
+                            writer_slice[address .. address + block_count]
+                                .copy_from_slice(&updates.blocks[block_index .. block_index + block_count]);
                         }
                     }
                 }
-                device.update_gpu_cache_transit_range(address_max);
             }
             GpuCacheBus::PixelBuffer { ref mut rows, .. } => {
                 for update in &updates.updates {
@@ -1003,8 +990,8 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
                     }
                 }
 
-                device.fill_vbo(buf_value, &updates.blocks, *count);
-                device.fill_vbo(buf_position, &position_data, *count);
+                _device.fill_vbo(buf_value, &updates.blocks, *count);
+                _device.fill_vbo(buf_position, &position_data, *count);
                 *count += position_data.len();
             }
         }
@@ -1014,7 +1001,7 @@ impl<B: hal::Backend> GpuCacheTexture<B> {
         let texture = self.texture.as_ref().unwrap();
         match self.bus {
             #[cfg(not(feature = "gleam"))]
-            GpuCacheBus::PMbuffer => 0,
+            GpuCacheBus::PersistentlyMappedBuffer { .. } => 0,
             GpuCacheBus::PixelBuffer { ref buffer, ref mut rows } => {
                 let rows_dirty = rows
                     .iter()
@@ -1244,12 +1231,13 @@ pub struct RendererVAOs {
 /// We have a separate `Renderer` instance for each instance of WebRender (generally
 /// one per OS window), and all instances share the same thread.
 pub struct Renderer<B: hal::Backend> {
-    result_rx: Receiver<ResultMsg>,
+    result_rx: Receiver<ResultMsg<B>>,
     debug_server: DebugServer,
     pub device: Device<B>,
     pending_texture_updates: Vec<TextureUpdateList>,
     pending_gpu_cache_updates: Vec<GpuCacheUpdateList>,
     pending_gpu_cache_clear: bool,
+    new_gpu_cache_bus: Option<GpuCacheBus>,
     pending_shader_updates: Vec<PathBuf>,
     active_documents: Vec<(DocumentId, RenderedDocument)>,
 
@@ -1682,6 +1670,12 @@ impl<B: hal::Backend> Renderer<B> {
             scene_tx.clone()
         };
 
+        #[cfg(not(feature = "gleam"))]
+        let device_clone = Arc::clone(&device.device);
+        #[cfg(not(feature = "gleam"))]
+        let heaps_clone = Arc::downgrade(&device.heaps);
+        #[cfg(not(feature = "gleam"))]
+        let non_coherent_atom_size_mask = (device.limits.non_coherent_atom_size - 1) as u64;
         thread::Builder::new().name(rb_thread_name.clone()).spawn(move || {
             register_thread_with_profiler(rb_thread_name.clone());
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
@@ -1699,7 +1693,7 @@ impl<B: hal::Backend> Renderer<B> {
                 blob_image_handler,
             );
 
-            let mut backend = RenderBackend::new(
+            let mut backend: RenderBackend<B> = RenderBackend::new(
                 api_rx,
                 payload_rx_for_backend,
                 result_tx,
@@ -1715,8 +1709,15 @@ impl<B: hal::Backend> Renderer<B> {
                 make_size_of_ops(),
                 debug_flags,
                 namespace_alloc_by_client,
+                #[cfg(not(feature = "gleam"))]
+                device_clone,
+                #[cfg(not(feature = "gleam"))]
+                heaps_clone,
+                #[cfg(not(feature = "gleam"))]
+                non_coherent_atom_size_mask,
             );
             backend.run(backend_profile_counters);
+            backend.deinit();
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
                 thread_listener.thread_stopped(&rb_thread_name);
             }
@@ -1740,6 +1741,7 @@ impl<B: hal::Backend> Renderer<B> {
             pending_texture_updates: Vec::new(),
             pending_gpu_cache_updates: Vec::new(),
             pending_gpu_cache_clear: false,
+            new_gpu_cache_bus: None,
             pending_shader_updates: Vec::new(),
             shaders,
             debug: LazyInitializedDebugRenderer::new(),
@@ -1917,6 +1919,48 @@ impl<B: hal::Backend> Renderer<B> {
                     }
                     self.pending_gpu_cache_updates.push(list);
                 }
+                #[cfg(not(feature="gleam"))]
+                ResultMsg::UpdateGpuCacheBuffer(mut update) => {
+                    if !matches!(self.gpu_cache_texture.bus, GpuCacheBus::PersistentlyMappedBuffer { .. }) {
+                        panic!("We should not receive this message if the cache bus is not a persistently mapped buffer!");
+                    }
+                    match update.buffer_update {
+                        BufferInfo::TransitRangeUpdate(new_range) => {
+                            self.device.gpu_cache_buffer.as_mut().unwrap().update_transit_range(new_range);
+                        }
+                        BufferInfo::BufferUpdate { buffer_memory_slice, new_buffer_info, old_buffer } => {
+                            self.new_gpu_cache_bus = Some(GpuCacheBus::PersistentlyMappedBuffer{ slice: Some(buffer_memory_slice) });
+                            self.device.set_gpu_cache_buffer(new_buffer_info);
+                            if let Some(buffer) = old_buffer {
+                                self.device.gpu_cache_buffers.insert(self.gpu_cache_texture.texture.as_ref().unwrap().id(), buffer);
+                            }
+                            self.pending_gpu_cache_clear = true;
+                        }
+                    }
+                    if update.frame_id > self.gpu_cache_frame_id {
+                        self.gpu_cache_frame_id = update.frame_id
+                    }
+
+                    for cmd in mem::replace(&mut update.debug_commands, Vec::new()) {
+                        match cmd {
+                            GpuCacheDebugCmd::Alloc(chunk) => {
+                                let row = chunk.address.v as usize;
+                                if row >= self.gpu_cache_debug_chunks.len() {
+                                    self.gpu_cache_debug_chunks.resize(row + 1, Vec::new());
+                                }
+                                self.gpu_cache_debug_chunks[row].push(chunk);
+                            },
+                            GpuCacheDebugCmd::Free(address) => {
+                                let chunks = &mut self.gpu_cache_debug_chunks[address.v as usize];
+                                let pos = chunks.iter()
+                                    .position(|x| x.address == address).unwrap();
+                                chunks.remove(pos);
+                            },
+                        }
+                    }
+                }
+                #[cfg(feature="gleam")]
+                ResultMsg::Phantom(..) => {}
                 ResultMsg::UpdateResources {
                     updates,
                     memory_pressure,
@@ -2200,7 +2244,7 @@ impl<B: hal::Backend> Renderer<B> {
                         }
                     }
                     #[cfg(not(feature = "gleam"))]
-                    GpuCacheBus::PMbuffer { .. } => {
+                    GpuCacheBus::PersistentlyMappedBuffer { .. } => {
                         info!("Invalidating GPU caches");
                     }
                     #[cfg(feature = "gleam")]
@@ -2535,6 +2579,7 @@ impl<B: hal::Backend> Renderer<B> {
                 (count + list.blocks.len(), cmp::max(height, list.height))
             });
 
+
         if max_requested_height > self.get_max_texture_size() && !self.gpu_cache_overflow {
             self.gpu_cache_overflow = true;
             self.renderer_errors.push(RendererError::MaxTextureSize);
@@ -2554,8 +2599,7 @@ impl<B: hal::Backend> Renderer<B> {
             if update_list.frame_id > self.gpu_cache_frame_id {
                 self.gpu_cache_frame_id = update_list.frame_id
             }
-            self.gpu_cache_texture
-                .update(&mut self.device, &update_list);
+            self.gpu_cache_texture.update(&mut self.device, &update_list);
         }
 
         let mut upload_time = TimeProfileCounter::new("GPU cache upload time", false);
@@ -2579,10 +2623,13 @@ impl<B: hal::Backend> Renderer<B> {
             #[cfg(not(feature="gleam"))]
             let use_scatter = false;
             #[cfg(not(feature="gleam"))]
-            let use_pmb = true;
+            let use_pmb = matches!(self.gpu_cache_texture.bus, GpuCacheBus::PersistentlyMappedBuffer { .. });
 
             let new_cache = GpuCacheTexture::new(&mut self.device, use_scatter, use_pmb).unwrap();
             let old_cache = mem::replace(&mut self.gpu_cache_texture, new_cache);
+            if use_pmb {
+                self.gpu_cache_texture.bus = self.new_gpu_cache_bus.take().unwrap();
+            }
             old_cache.deinit(&mut self.device);
             self.pending_gpu_cache_clear = false;
         }
@@ -2599,7 +2646,7 @@ impl<B: hal::Backend> Renderer<B> {
         );
 
         #[cfg(not(feature = "gleam"))]
-        self.device.bind_cache_buffer(self.gpu_cache_texture.texture.as_ref().unwrap());
+        self.device.transit_gpu_cache_buffer();
     }
 
     fn update_texture_cache(&mut self) {


### PR DESCRIPTION
The current solution:
- The `B::Device` and `Heaps<B>` are shared across the Renderer and RenderBackend threads.
- We create and store the active `PMBuffer` in the `RenderBackend`, and we write the updates in place instead of sendening them to the `Renderer`.
- The active `PMBuffer`'s `B::Device` buffer handle is shared with the `Renderer` so `Device` can use it in the descriptor sets.
- If we have to recreate the `PMBuffer` (upon clear or resize), the old `PMBuffer` is sent to the `Renderer` and we store it until the frame(s) which still use it are in flight.
- Upon `PMBuffer` recreation a `BufferMemorySlice` struct is also sent to the Renderer which is used for handling `DeferredResolve`s. This is a workaround until the main `Devic`e logic is in the Renderer thread.

~The last missing thing is transitioning the `PMBuffer`s to their proper state. For this we either record the transition in the `RenderBackend` and send it to the `Renderer` thread or send additional info from the state of the `PMBuffer` and use it for the transitions in the `Renderer`.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/307)
<!-- Reviewable:end -->
