### PR TITLE
Refactor pipeline barriers

### DIFF
--- a/webrender/src/device/gfx/command.rs
+++ b/webrender/src/device/gfx/command.rs
@@ -27,13 +27,12 @@ impl<B: hal::Backend> CommandPool<B> {
         }
     }
 
-    pub(super) fn command_buffers(&self) -> &[B::CommandBuffer] {
-        &self.command_buffers
+    pub fn remove_cmd_buffer(&mut self) -> B::CommandBuffer {
+        self.command_buffers.remove(0)
     }
 
-    pub fn command_buffer_mut(&mut self) -> &mut B::CommandBuffer {
-        // 1 command_pool/frame, 1 command_buffer/command_pool
-        &mut self.command_buffers[0]
+    pub fn return_cmd_buffer(&mut self, cmd_buffer: B::CommandBuffer) {
+        self.command_buffers.insert(0, cmd_buffer);
     }
 
     pub(super) unsafe fn reset(&mut self) {

--- a/webrender/src/device/gfx/descriptor.rs
+++ b/webrender/src/device/gfx/descriptor.rs
@@ -5,7 +5,6 @@
 use arrayvec::ArrayVec;
 use hal::Device;
 use hal::pso::{DescriptorSetLayoutBinding, DescriptorType as DT, ShaderStageFlags as SSF};
-use hal::command::RawCommandBuffer;
 use internal_types::FastHashMap;
 use rendy_descriptor::{DescriptorAllocator, DescriptorRanges, DescriptorSet};
 use rendy_memory::Heaps;
@@ -338,7 +337,6 @@ impl<K, B, F> DescriptorSetHandler<K, B, F>
         &mut self,
         bound_textures: &[u32; RENDERER_TEXTURE_COUNT],
         bound_samplers: &[TextureFilter; RENDERER_TEXTURE_COUNT],
-        cmd_buffer: &mut B::CommandBuffer,
         bindings: K,
         images: &FastHashMap<TextureId, Image<B>>,
         storage_buffer: Option<&B::Buffer>,
@@ -389,24 +387,6 @@ impl<K, B, F> DescriptorSetHandler<K, B, F>
         }
         for index in range {
             let image = &images[&bound_textures[index]].core;
-            // We need to transit the image, even though it's bound in the descriptor set
-            let mut src_stage = Some(hal::pso::PipelineStage::empty());
-            if let Some(barrier) = image.transit(
-                hal::image::Access::SHADER_READ,
-                hal::image::Layout::ShaderReadOnlyOptimal,
-                image.subresource_range.clone(),
-                src_stage.as_mut(),
-            ) {
-                unsafe {
-                    // TODO(zakorgy): combine these barriers into a single one
-                    cmd_buffer.pipeline_barrier(
-                        src_stage.unwrap()
-                            .. hal::pso::PipelineStage::FRAGMENT_SHADER | hal::pso::PipelineStage::VERTEX_SHADER,
-                        hal::memory::Dependencies::empty(),
-                        &[barrier],
-                    );
-                }
-            }
             if let Some(ref set) = new_set {
                 let sampler = if index < PER_DRAW_TEXTURE_COUNT {
                     match bound_samplers[index] {

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -2943,8 +2943,8 @@ impl<B: hal::Backend> Device<B> {
                 }],
             );
             if let Some(barrier) = image.transit(
-                hal::image::Access::empty(),
-                hal::image::Layout::ColorAttachmentOptimal,
+                hal::image::Access::MEMORY_READ,
+                hal::image::Layout::Present,
                 image.subresource_range.clone(),
             ) {
                 cmd_buffer.pipeline_barrier(
@@ -3511,7 +3511,7 @@ impl<B: hal::Backend> Device<B> {
                                 image.subresource_range.clone(),
                             ) {
                                 self.command_buffer.pipeline_barrier(
-                                    PipelineStage::COLOR_ATTACHMENT_OUTPUT
+                                    PipelineStage::TRANSFER
                                         .. PipelineStage::COLOR_ATTACHMENT_OUTPUT,
                                     hal::memory::Dependencies::empty(),
                                     &[barrier],
@@ -3562,13 +3562,13 @@ impl<B: hal::Backend> Device<B> {
             let image = &self.frame_images[self.current_frame_id];
             unsafe {
                 if let Some(barrier) = image.transit(
-                    hal::image::Access::empty(),
+                    hal::image::Access::MEMORY_READ,
                     hal::image::Layout::Present,
                     image.subresource_range.clone(),
                 ) {
                     self.command_buffer.pipeline_barrier(
                         PipelineStage::COLOR_ATTACHMENT_OUTPUT
-                            .. PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+                            .. PipelineStage::TRANSFER,
                         hal::memory::Dependencies::empty(),
                         &[barrier],
                     );

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -1867,10 +1867,10 @@ impl<B: hal::Backend> Device<B> {
         let (fbo_id, dimensions, depth_available) = match texture_target {
             DrawTarget::Default(dim) => {
                 if let DrawTargetUsage::CopyOnly = usage {
-                    if let Some(barrier) = self.frame_images[self.next_id].transit(
+                    if let Some(barrier) = self.frame_images[self.current_frame_id].transit(
                         hal::image::Access::TRANSFER_WRITE,
                         hal::image::Layout::TransferDstOptimal,
-                        self.frame_images[self.next_id].subresource_range.clone(),
+                        self.frame_images[self.current_frame_id].subresource_range.clone(),
                     ) {
                         unsafe {
                             self.command_buffer.pipeline_barrier(

--- a/webrender/src/device/gfx/image.rs
+++ b/webrender/src/device/gfx/image.rs
@@ -128,7 +128,6 @@ impl<B: hal::Backend> ImageCore<B> {
         access: hal::image::Access,
         layout: hal::image::Layout,
         range: hal::image::SubresourceRange,
-        stage: Option<&mut hal::pso::PipelineStage>,
     ) -> Option<hal::memory::Barrier<B>> {
         let src_state = self.state.get();
         if src_state == (access, layout) {
@@ -141,16 +140,6 @@ impl<B: hal::Backend> ImageCore<B> {
                 families: None,
                 range,
             };
-            use hal::image::Access;
-            use hal::pso::PipelineStage;
-            if let Some(stage) = stage {
-                *stage = match src_state.0 {
-                    Access::SHADER_READ => PipelineStage::FRAGMENT_SHADER,
-                    state if state.contains(Access::DEPTH_STENCIL_ATTACHMENT_READ)
-                        || state.contains(Access::DEPTH_STENCIL_ATTACHMENT_WRITE) => PipelineStage::LATE_FRAGMENT_TESTS,
-                    _ => hal::pso::PipelineStage::COLOR_ATTACHMENT_OUTPUT,
-                };
-            }
             Some(barrier)
         }
     }
@@ -215,6 +204,7 @@ impl<B: hal::Backend> Image<B> {
         rect: DeviceIntRect,
         layer_index: i32,
         image_data: &[u8],
+        draw_target: bool,
     ) {
         use hal::pso::PipelineStage;
         let pos = rect.origin;
@@ -223,8 +213,6 @@ impl<B: hal::Backend> Image<B> {
         let buffer = staging_buffer_pool.buffer();
 
         unsafe {
-            let begin_state = self.core.state.get();
-            let mut pre_stage = Some(PipelineStage::COLOR_ATTACHMENT_OUTPUT);
             let barriers = buffer
                 .transit(hal::buffer::Access::TRANSFER_READ)
                 .into_iter()
@@ -232,11 +220,24 @@ impl<B: hal::Backend> Image<B> {
                     hal::image::Access::TRANSFER_WRITE,
                     hal::image::Layout::TransferDstOptimal,
                     self.core.subresource_range.clone(),
-                    pre_stage.as_mut(),
                 ));
 
+            let (prev_stage, prev_access, prev_layout) = if draw_target {
+                (
+                    PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+                    hal::image::Access::COLOR_ATTACHMENT_WRITE,
+                    hal::image::Layout::ColorAttachmentOptimal,
+                )
+            } else {
+                (
+                    PipelineStage::VERTEX_SHADER | PipelineStage::FRAGMENT_SHADER,
+                    hal::image::Access::SHADER_READ,
+                    hal::image::Layout::ShaderReadOnlyOptimal,
+                )
+            };
+
             cmd_buffer.pipeline_barrier(
-                pre_stage.unwrap() .. PipelineStage::TRANSFER,
+                prev_stage .. PipelineStage::TRANSFER,
                 hal::memory::Dependencies::empty(),
                 barriers,
             );
@@ -268,13 +269,12 @@ impl<B: hal::Backend> Image<B> {
             );
 
             if let Some(barrier) = self.core.transit(
-                begin_state.0,
-                begin_state.1,
+                prev_access,
+                prev_layout,
                 self.core.subresource_range.clone(),
-               None,
             ) {
                 cmd_buffer.pipeline_barrier(
-                    PipelineStage::TRANSFER .. pre_stage.unwrap(),
+                    PipelineStage::TRANSFER .. prev_stage,
                     hal::memory::Dependencies::empty(),
                     &[barrier],
                 );

--- a/webrender/src/gpu_glyph_renderer.rs
+++ b/webrender/src/gpu_glyph_renderer.rs
@@ -209,11 +209,15 @@ impl<B: hal::Backend> Renderer<B> {
                                                     projection,
                                                     &mut self.renderer_errors);
 
-        self.device.bind_draw_target(DrawTarget::Texture {
-            texture: &current_page.texture,
-            layer: 0,
-            with_depth: false,
-        });
+        self.device.bind_draw_target(
+            DrawTarget::Texture {
+                texture: &current_page.texture,
+                layer: 0,
+                with_depth: false,
+            },
+            #[cfg(not(feature="gleam"))]
+            DrawTargetUsage::Draw,
+        );
         self.device.clear_target(Some([0.0, 0.0, 0.0, 0.0]), None, None);
 
         self.device.set_blend(true);

--- a/webrender/src/gpu_glyph_renderer.rs
+++ b/webrender/src/gpu_glyph_renderer.rs
@@ -12,6 +12,8 @@ use device::{desc, ShaderKind};
 use device::{Device, PrimitiveType, ShaderPrecacheFlags, Texture};
 use device::{DrawTarget, TextureFilter, TextureSampler, VAO, VertexArrayKind};
 use euclid::{Point2D, Size2D, Transform3D, TypedVector2D, Vector2D};
+#[cfg(not(feature = "gleam"))]
+use device::DrawTargetUsage;
 use hal;
 use internal_types::RenderTargetInfo;
 use pathfinder_gfx_utils::ShelfBinPacker;
@@ -215,7 +217,7 @@ impl<B: hal::Backend> Renderer<B> {
                 layer: 0,
                 with_depth: false,
             },
-            #[cfg(not(feature="gleam"))]
+            #[cfg(not(feature = "gleam"))]
             DrawTargetUsage::Draw,
         );
         self.device.clear_target(Some([0.0, 0.0, 0.0, 0.0]), None, None);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -49,7 +49,7 @@ use device::query::GpuTimer;
 #[cfg(feature = "gleam")]
 use device::{CustomVAO, Program, VBO};
 #[cfg(not(feature="gleam"))]
-use device::BufferMemorySlice;
+use device::{BufferMemorySlice, DrawTargetUsage};
 use euclid::rect;
 use euclid::Transform3D;
 use frame_builder::{ChasePrimitive, FrameBuilderConfig};
@@ -2758,11 +2758,15 @@ impl<B: hal::Backend> Renderer<B> {
                             size
                         }
                         TextureUpdateSource::DebugClear => {
-                            self.device.bind_draw_target(DrawTarget::Texture {
-                                texture,
-                                layer: layer_index as usize,
-                                with_depth: false,
-                            });
+                            self.device.bind_draw_target(
+                                DrawTarget::Texture {
+                                    texture,
+                                    layer: layer_index as usize,
+                                    with_depth: false,
+                                },
+                                #[cfg(not(feature="gleam"))]
+                                DrawTargetUsage::Draw,
+                            );
                             self.device.clear_target(
                                 Some(TEXTURE_CACHE_DBG_CLEAR_COLOR),
                                 None,
@@ -2884,7 +2888,11 @@ impl<B: hal::Backend> Renderer<B> {
             layer: readback_layer.0 as usize,
             with_depth: false,
         };
-        self.device.bind_draw_target(cache_draw_target);
+        self.device.bind_draw_target(
+            cache_draw_target,
+            #[cfg(not(feature="gleam"))]
+            DrawTargetUsage::CopyOnly,
+        );
 
         let mut src = DeviceIntRect::new(
             source_screen_origin + (backdrop_rect.origin - backdrop_screen_origin),
@@ -2905,7 +2913,11 @@ impl<B: hal::Backend> Renderer<B> {
 
         // Restore draw target to current pass render target + layer, and reset
         // the read target.
-        self.device.bind_draw_target(draw_target);
+        self.device.bind_draw_target(
+            draw_target,
+            #[cfg(not(feature="gleam"))]
+            DrawTargetUsage::Draw,
+        );
         self.device.reset_read_target();
 
         if uses_scissor {
@@ -3020,7 +3032,11 @@ impl<B: hal::Backend> Renderer<B> {
 
         {
             let _timer = self.gpu_profile.start_timer(GPU_TAG_SETUP_TARGET);
-            self.device.bind_draw_target(draw_target);
+            self.device.bind_draw_target(
+                draw_target,
+                #[cfg(not(feature="gleam"))]
+                DrawTargetUsage::Draw,
+            );
             self.device.disable_depth();
             self.set_blend(false, framebuffer_kind);
 
@@ -3314,11 +3330,15 @@ impl<B: hal::Backend> Renderer<B> {
                         .resolve(&blit.target.texture_id)
                         .expect("BUG: invalid target texture");
 
-                    self.device.bind_draw_target(DrawTarget::Texture {
-                        texture,
-                        layer: blit.target.texture_layer as usize,
-                        with_depth: false,
-                    });
+                    self.device.bind_draw_target(
+                        DrawTarget::Texture {
+                            texture,
+                            layer: blit.target.texture_layer as usize,
+                            with_depth: false,
+                        },
+                        #[cfg(not(feature="gleam"))]
+                        DrawTargetUsage::CopyOnly,
+                    );
 
                     let mut src_rect = DeviceIntRect::new(
                         blit.src_offset,
@@ -3348,7 +3368,11 @@ impl<B: hal::Backend> Renderer<B> {
                     );
                 }
 
-                self.device.bind_draw_target(draw_target);
+                self.device.bind_draw_target(
+                    draw_target,
+                    #[cfg(not(feature="gleam"))]
+                    DrawTargetUsage::Draw,
+                );
             }
         }
 
@@ -3403,7 +3427,11 @@ impl<B: hal::Backend> Renderer<B> {
 
         {
             let _timer = self.gpu_profile.start_timer(GPU_TAG_SETUP_TARGET);
-            self.device.bind_draw_target(draw_target);
+            self.device.bind_draw_target(
+                draw_target,
+                #[cfg(not(feature="gleam"))]
+                DrawTargetUsage::Draw,
+            );
             self.device.disable_depth();
             self.device.disable_depth_write();
 
@@ -3567,11 +3595,15 @@ impl<B: hal::Backend> Renderer<B> {
             let texture = self.texture_resolver
                 .resolve(&texture_source)
                 .expect("BUG: invalid target texture");
-            self.device.bind_draw_target(DrawTarget::Texture {
-                texture,
-                layer,
-                with_depth: false,
-            });
+            self.device.bind_draw_target(
+                DrawTarget::Texture {
+                    texture,
+                    layer,
+                    with_depth: false,
+                },
+                #[cfg(not(feature="gleam"))]
+                DrawTargetUsage::Draw,
+            );
         }
 
         self.device.disable_depth();
@@ -4534,11 +4566,15 @@ impl<B: hal::Backend> Renderer<B> {
     /// Clears all the layers of a texture with a given color.
     fn clear_texture(&mut self, texture: &Texture, color: [f32; 4]) {
         for i in 0..texture.get_layer_count() {
-            self.device.bind_draw_target(DrawTarget::Texture {
-                texture: &texture,
-                layer: i as usize,
-                with_depth: false,
-            });
+            self.device.bind_draw_target(
+                DrawTarget::Texture {
+                    texture: &texture,
+                    layer: i as usize,
+                    with_depth: false,
+                },
+                #[cfg(not(feature="gleam"))]
+                DrawTargetUsage::Draw,
+            );
             self.device.clear_target(Some(color), None, None);
         }
     }


### PR DESCRIPTION
Change the transition logic to be more transparent, and don't rely on the previous image state to pick the source pipeline stage.
Changed the default layot to `ShaderReadonlyOptiomal (SRO)` for new images instead of `ColorAttachmentOptimal (CAO)`.
If a texture is bound as draw target it's corresponding image is transitioned to the `CAO` layout. If a new texture with a new images is bound as draw target we transit back the old image to `SRO`.
If an image is transitioned for some purpose (copy, blit, clear) we always transit back to the previous state which could be only `SRO` or `CAO`.
There are two exceptions frame and depth images:
- Frame images are always in `CAO` layout (no `SRO`).
- Depth images are always in `DepthStencilAttachmentOptimal (DSAO)` layout, since there is only one operation which requires a layout transition for these but after that we return to `DSAO`.

Benefit: To rework our render pass logic it's good to know that our render target is in the proper state.

Things left:
- [ ] Fix DX12 backend debug layer errors which came in with these changes
- [x] Check these changes with metal backend