### PR TITLE
Refactor render passes part 1

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -385,6 +385,9 @@ impl DebugRenderer {
                 true,
             );
 
+            #[cfg(not(feature = "gleam"))]
+            device.begin_render_pass();
+
             // Triangles
             if !self.tri_vertices.is_empty() {
                 device.bind_program(&self.color_program);
@@ -426,6 +429,9 @@ impl DebugRenderer {
                 );
                 device.draw_triangles_u32(0, self.font_indices.len() as i32);
             }
+
+            #[cfg(not(feature = "gleam"))]
+            device.end_render_pass();
         }
 
         self.font_indices.clear();

--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -3121,16 +3121,14 @@ impl<B: hal::Backend> Device<B> {
             self.depth_available,
             "Enabling depth test without depth target"
         );
-        if mem::replace(&mut self.current_depth_test, Some(LESS_EQUAL_TEST)).is_none() && self.inside_render_pass {
-            self.end_render_pass();
-            self.begin_render_pass();
-        }
+        self.current_depth_test = Some(LESS_EQUAL_TEST);
     }
 
     pub fn disable_depth(&mut self) {
-        if mem::replace(&mut self.current_depth_test, None).is_some() && self.inside_render_pass {
-            self.end_render_pass();
-            self.begin_render_pass();
+        if self.depth_available {
+            self.current_depth_test = Some(LESS_EQUAL_TEST);
+        } else {
+            self.current_depth_test =  None;
         }
     }
 
@@ -3145,10 +3143,6 @@ impl<B: hal::Backend> Device<B> {
             "Enabling depth test without depth target"
         );
         self.current_depth_test = Some(LESS_EQUAL_WRITE);
-        if mem::replace(&mut self.current_depth_test, Some(LESS_EQUAL_WRITE)).is_none() && self.inside_render_pass {
-            self.end_render_pass();
-            self.begin_render_pass();
-        }
     }
 
     pub fn disable_depth_write(&mut self) {

--- a/webrender/src/device/gfx/image.rs
+++ b/webrender/src/device/gfx/image.rs
@@ -9,7 +9,7 @@ use rendy_memory::{Block, Heaps, MemoryBlock, MemoryUsageValue};
 
 use std::cell::Cell;
 use super::buffer::BufferPool;
-use super::render_pass::RenderPass;
+use super::render_pass::HalRenderPasses;
 use super::TextureId;
 use super::PipelineBarrierInfo;
 use super::super::{RBOId, Texture};
@@ -289,7 +289,7 @@ impl<B: hal::Backend> Framebuffer<B> {
         texture: &Texture,
         image: &Image<B>,
         layer_index: u16,
-        render_pass: &RenderPass<B>,
+        render_passes: &HalRenderPasses<B>,
         rbo: RBOId,
         depth: Option<&B::ImageView>,
     ) -> Self {
@@ -320,13 +320,13 @@ impl<B: hal::Backend> Framebuffer<B> {
         let fbo = unsafe {
             if rbo != RBOId(0) {
                 device.create_framebuffer(
-                    render_pass.get_render_pass(texture.format, true),
+                    render_passes.get_render_pass(texture.format, true),
                     Some(&image_view).into_iter().chain(depth.into_iter()),
                     extent,
                 )
             } else {
                 device.create_framebuffer(
-                    render_pass.get_render_pass(texture.format, false),
+                    render_passes.get_render_pass(texture.format, false),
                     Some(&image_view),
                     extent,
                 )

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -32,9 +32,16 @@ const SPECIALIZATION_FEATURES: &'static [&'static str] = &[
     "DEBUG_OVERDRAW",
 ];
 
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub(super) enum RenderPassDepthState {
+    Enabled,
+    Disabled,
+}
+
+type PipelineKey = (Option<hal::pso::BlendState>, RenderPassDepthState, Option<hal::pso::DepthTest>);
 
 pub(crate) struct Program<B: hal::Backend> {
-    pipelines: FastHashMap<(Option<hal::pso::BlendState>, Option<hal::pso::DepthTest>), B::GraphicsPipeline>,
+    pipelines: FastHashMap<PipelineKey, B::GraphicsPipeline>,
     pub(super) vertex_buffer: Option<SmallVec<[VertexBufferHandler<B>; 1]>>,
     pub(super) index_buffer: Option<SmallVec<[VertexBufferHandler<B>; 1]>>,
     pub(super) shader_name: String,
@@ -140,80 +147,108 @@ impl<B: hal::Backend> Program<B> {
             use hal::pso::{BlendState};
             use super::blend_state::*;
             use super::{LESS_EQUAL_TEST, LESS_EQUAL_WRITE};
+            use self::RenderPassDepthState as RPDS;
 
             let pipeline_states = match shader_kind {
                 ShaderKind::Cache(VertexArrayKind::Scale) => [
-                    (None, None),
-                    (Some(BlendState::MULTIPLY), None),
+                    (None, RPDS::Enabled, None),
+                    (None, RPDS::Disabled, None),
+                    (Some(BlendState::MULTIPLY), RPDS::Enabled, None),
+                    (Some(BlendState::MULTIPLY), RPDS::Disabled, None),
                 ]
                 .into_iter(),
                 ShaderKind::Cache(VertexArrayKind::Blur) => [
-                    (None, None),
-                    (None, Some(LESS_EQUAL_TEST)),
+                    (None, RPDS::Enabled, None),
+                    (None, RPDS::Disabled, None),
+                    (None, RPDS::Enabled, Some(LESS_EQUAL_TEST)),
                 ]
                 .into_iter(),
                 ShaderKind::Cache(VertexArrayKind::Border)
-                | ShaderKind::Cache(VertexArrayKind::LineDecoration) => {
-                    [(Some(BlendState::PREMULTIPLIED_ALPHA), None)].into_iter()
-                }
-                ShaderKind::ClipCache => [(Some(BlendState::MULTIPLY), None)].into_iter(),
+                    | ShaderKind::Cache(VertexArrayKind::LineDecoration) => [
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, None),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Disabled, None),
+                ].into_iter(),
+                ShaderKind::ClipCache => [
+                    (Some(BlendState::MULTIPLY), RPDS::Enabled, None),
+                    (Some(BlendState::MULTIPLY), RPDS::Disabled, None),
+                ].into_iter(),
                 ShaderKind::Text => {
                     if features.contains(&"DUAL_SOURCE_BLENDING") {
                         [
-                            (Some(BlendState::PREMULTIPLIED_ALPHA), None),
-                            (Some(BlendState::PREMULTIPLIED_ALPHA), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), None),
-                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_PASS0), None),
-                            (Some(SUBPIXEL_PASS0), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_PASS1), None),
-                            (Some(SUBPIXEL_PASS1), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_DUAL_SOURCE), None),
-                            (Some(SUBPIXEL_DUAL_SOURCE), Some(LESS_EQUAL_TEST)),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, None),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Disabled, None),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_PASS0), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_PASS0), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_PASS0), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_PASS1), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_PASS1), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_PASS1), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_DUAL_SOURCE), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_DUAL_SOURCE), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_DUAL_SOURCE), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
                         ]
                         .into_iter()
                     } else {
                         [
-                            (Some(BlendState::PREMULTIPLIED_ALPHA), None),
-                            (Some(BlendState::PREMULTIPLIED_ALPHA), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), None),
-                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_PASS0), None),
-                            (Some(SUBPIXEL_PASS0), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_PASS1), None),
-                            (Some(SUBPIXEL_PASS1), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), Some(LESS_EQUAL_TEST)),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), None),
-                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), Some(LESS_EQUAL_TEST)),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, None),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Disabled, None),
+                            (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_CONSTANT_TEXT_COLOR), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_PASS0), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_PASS0), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_PASS0), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_PASS1), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_PASS1), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_PASS1), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS0), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS1), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Enabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Disabled, None),
+                            (Some(SUBPIXEL_WITH_BG_COLOR_PASS2), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
                         ]
                         .into_iter()
                     }
                 }
-                ShaderKind::DebugColor | ShaderKind::DebugFont => {
-                    [(Some(BlendState::PREMULTIPLIED_ALPHA), None)].into_iter()
-                }
+                ShaderKind::DebugColor | ShaderKind::DebugFont => [
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, None),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Disabled, None),
+                ].into_iter(),
                 _ => [
-                    (None, None),
-                    (None, Some(LESS_EQUAL_TEST)),
-                    (None, Some(LESS_EQUAL_WRITE)),
-                    (Some(ALPHA), None),
-                    (Some(ALPHA), Some(LESS_EQUAL_TEST)),
-                    (Some(ALPHA), Some(LESS_EQUAL_WRITE)),
-                    (Some(BlendState::PREMULTIPLIED_ALPHA), None),
-                    (Some(BlendState::PREMULTIPLIED_ALPHA), Some(LESS_EQUAL_TEST)),
-                    (Some(BlendState::PREMULTIPLIED_ALPHA), Some(LESS_EQUAL_WRITE)),
-                    (Some(PREMULTIPLIED_DEST_OUT), None),
-                    (Some(PREMULTIPLIED_DEST_OUT), Some(LESS_EQUAL_TEST)),
-                    (Some(PREMULTIPLIED_DEST_OUT), Some(LESS_EQUAL_WRITE)),
+                    (None, RPDS::Enabled, None),
+                    (None, RPDS::Disabled, None),
+                    (None, RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                    (None, RPDS::Enabled, Some(LESS_EQUAL_WRITE)),
+                    (Some(ALPHA), RPDS::Enabled, None),
+                    (Some(ALPHA), RPDS::Disabled, None),
+                    (Some(ALPHA), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                    (Some(ALPHA), RPDS::Enabled, Some(LESS_EQUAL_WRITE)),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, None),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Disabled, None),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                    (Some(BlendState::PREMULTIPLIED_ALPHA), RPDS::Enabled, Some(LESS_EQUAL_WRITE)),
+                    (Some(PREMULTIPLIED_DEST_OUT), RPDS::Enabled, None),
+                    (Some(PREMULTIPLIED_DEST_OUT), RPDS::Disabled, None),
+                    (Some(PREMULTIPLIED_DEST_OUT), RPDS::Enabled, Some(LESS_EQUAL_TEST)),
+                    (Some(PREMULTIPLIED_DEST_OUT), RPDS::Enabled, Some(LESS_EQUAL_WRITE)),
                 ]
                 .into_iter(),
             };
@@ -229,11 +264,18 @@ impl<B: hal::Backend> Program<B> {
                 _ => surface_format,
             };
 
-            let create_desc = |(blend_state, depth_test)| {
+            let create_desc = |(blend_state, render_pass_depth_state, depth_test)| {
+                let depth_enabled = match depth_test {
+                    Some(_) => true,
+                    None => match render_pass_depth_state {
+                        RenderPassDepthState::Enabled => true,
+                        RenderPassDepthState::Disabled => false,
+                    },
+                };
                 let subpass = hal::pass::Subpass {
                     index: 0,
                     main_pass: render_passes
-                        .get_render_pass(format, depth_test != None),
+                        .get_render_pass(format, depth_enabled),
                 };
                 let mut pipeline_descriptor = hal::pso::GraphicsPipelineDesc::new(
                     shader_entries.clone(),
@@ -263,7 +305,9 @@ impl<B: hal::Backend> Program<B> {
                 pipeline_descriptor
             };
 
-            let pipelines_descriptors = pipeline_states.clone().map(|ps| create_desc(*ps));
+            let pipelines_descriptors = pipeline_states
+                .clone()
+                .map(|ps| create_desc(*ps));
 
             let pipelines =
                 unsafe { device.create_graphics_pipelines(pipelines_descriptors, pipeline_cache) }
@@ -272,10 +316,10 @@ impl<B: hal::Backend> Program<B> {
             let mut states = pipeline_states
                 .cloned()
                 .zip(pipelines.map(|pipeline| pipeline.expect("Pipeline creation failed")))
-                .collect::<FastHashMap<(Option<hal::pso::BlendState>, Option<hal::pso::DepthTest>), B::GraphicsPipeline>>();
+                .collect::<FastHashMap<PipelineKey, B::GraphicsPipeline>>();
 
             if features.contains(&"DEBUG_OVERDRAW") {
-                let pipeline_state = (Some(OVERDRAW), Some(LESS_EQUAL_TEST));
+                let pipeline_state = (Some(OVERDRAW), RPDS::Enabled, Some(LESS_EQUAL_TEST));
                 let pipeline_descriptor = create_desc(pipeline_state);
                 let pipeline = unsafe {
                     device.create_graphics_pipeline(&pipeline_descriptor, pipeline_cache)
@@ -336,6 +380,7 @@ impl<B: hal::Backend> Program<B> {
         blend_state: Option<hal::pso::BlendState>,
         blend_color: ColorF,
         depth_test: Option<hal::pso::DepthTest>,
+        render_pass_depth_state: RenderPassDepthState,
         scissor_rect: Option<DeviceIntRect>,
         next_id: usize,
         pipeline_layout: &B::PipelineLayout,
@@ -373,10 +418,10 @@ impl<B: hal::Backend> Program<B> {
             cmd_buffer.bind_graphics_pipeline(
                 &self
                     .pipelines
-                    .get(&(blend_state, depth_test))
+                    .get(&(blend_state, render_pass_depth_state, depth_test))
                     .expect(&format!(
-                        "The blend state {:?} with depth test {:?} not found for {} program!",
-                        blend_state, depth_test, self.shader_name
+                        "The blend state {:?} with depth test {:?} and render_pass_depth_state {:?} not found for {} program!",
+                        blend_state, depth_test, render_pass_depth_state, self.shader_name
                     )),
             );
 

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow::{Borrowed};
 
 use super::buffer::{InstanceBufferHandler, VertexBufferHandler};
 use super::blend_state::SUBPIXEL_CONSTANT_TEXT_COLOR;
-use super::render_pass::RenderPass;
+use super::render_pass::HalRenderPasses;
 use super::PipelineRequirements;
 use super::super::{ShaderKind, VertexArrayKind};
 use super::super::super::shader_source;
@@ -52,7 +52,7 @@ impl<B: hal::Backend> Program<B> {
         shader_name: &str,
         features: &[&str],
         shader_kind: ShaderKind,
-        render_pass: &RenderPass<B>,
+        render_passes: &HalRenderPasses<B>,
         frame_count: usize,
         shader_modules: &mut FastHashMap<String, (B::ShaderModule, B::ShaderModule)>,
         pipeline_cache: Option<&B::PipelineCache>,
@@ -232,7 +232,7 @@ impl<B: hal::Backend> Program<B> {
             let create_desc = |(blend_state, depth_test)| {
                 let subpass = hal::pass::Subpass {
                     index: 0,
-                    main_pass: render_pass
+                    main_pass: render_passes
                         .get_render_pass(format, depth_test != None),
                 };
                 let mut pipeline_descriptor = hal::pso::GraphicsPipelineDesc::new(

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -4,7 +4,7 @@
 
 use api::{ColorF, DeviceIntRect, ImageFormat};
 use hal::{self, Device as BackendDevice};
-use hal::command::{RawCommandBuffer, SubpassContents};
+use hal::command::RawCommandBuffer;
 use internal_types::FastHashMap;
 use smallvec::SmallVec;
 use rendy_memory::Heaps;
@@ -329,13 +329,10 @@ impl<B: hal::Backend> Program<B> {
         &mut self,
         cmd_buffer: &mut B::CommandBuffer,
         viewport: hal::pso::Viewport,
-        render_pass: &B::RenderPass,
-        frame_buffer: &B::Framebuffer,
         desc_set_per_draw: &B::DescriptorSet,
         desc_set_per_pass: Option<&B::DescriptorSet>,
         desc_set_per_frame: &B::DescriptorSet,
         desc_set_locals: Option<&B::DescriptorSet>,
-        clear_values: &[hal::command::ClearValueRaw],
         blend_state: Option<hal::pso::BlendState>,
         blend_color: ColorF,
         depth_test: Option<hal::pso::DepthTest>,
@@ -401,13 +398,6 @@ impl<B: hal::Backend> Program<B> {
                 cmd_buffer.set_blend_constants(blend_color.to_array());
             }
 
-            cmd_buffer.begin_render_pass(
-                render_pass,
-                frame_buffer,
-                viewport.rect,
-                clear_values,
-                SubpassContents::Inline,
-            );
             if let Some(ref index_buffer) = self.index_buffer {
                 cmd_buffer.bind_vertex_buffers(0, Some((&vertex_buffer.buffer().buffer, 0)));
                 cmd_buffer.bind_index_buffer(hal::buffer::IndexBufferView {
@@ -440,7 +430,6 @@ impl<B: hal::Backend> Program<B> {
                     );
                 }
             }
-            cmd_buffer.end_render_pass();
         }
     }
 

--- a/webrender/src/device/gfx/render_pass.rs
+++ b/webrender/src/device/gfx/render_pass.rs
@@ -45,8 +45,8 @@ impl<B: hal::Backend> HalRenderPasses<B> {
             format: Some(hal::format::Format::R8Unorm),
             samples: 1,
             ops: hal::pass::AttachmentOps::new(
-                hal::pass::AttachmentLoadOp::DontCare,
-                hal::pass::AttachmentStoreOp::Store,
+                hal::pass::AttachmentLoadOp::Load,
+                hal::pass::AttachmentStoreOp::DontCare,
             ),
             stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
             layouts: hal::image::Layout::ColorAttachmentOptimal
@@ -57,8 +57,8 @@ impl<B: hal::Backend> HalRenderPasses<B> {
             format: Some(surface_format),
             samples: 1,
             ops: hal::pass::AttachmentOps::new(
-                hal::pass::AttachmentLoadOp::DontCare,
-                hal::pass::AttachmentStoreOp::Store,
+                hal::pass::AttachmentLoadOp::Load,
+                hal::pass::AttachmentStoreOp::DontCare,
             ),
             stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
             layouts: hal::image::Layout::ColorAttachmentOptimal
@@ -69,8 +69,8 @@ impl<B: hal::Backend> HalRenderPasses<B> {
             format: Some(depth_format),
             samples: 1,
             ops: hal::pass::AttachmentOps::new(
-                hal::pass::AttachmentLoadOp::DontCare,
-                hal::pass::AttachmentStoreOp::Store,
+                hal::pass::AttachmentLoadOp::Load,
+                hal::pass::AttachmentStoreOp::DontCare,
             ),
             stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
             layouts: hal::image::Layout::DepthStencilAttachmentOptimal

--- a/webrender/src/device/gfx/render_pass.rs
+++ b/webrender/src/device/gfx/render_pass.rs
@@ -5,14 +5,14 @@
 use api::ImageFormat;
 use hal::Device;
 
-pub(super) struct RenderPass<B: hal::Backend> {
+pub(super) struct HalRenderPasses<B: hal::Backend> {
     pub(super) r8: B::RenderPass,
     pub(super) r8_depth: B::RenderPass,
     pub(super) bgra8: B::RenderPass,
     pub(super) bgra8_depth: B::RenderPass,
 }
 
-impl<B: hal::Backend> RenderPass<B> {
+impl<B: hal::Backend> HalRenderPasses<B> {
     pub(super) fn get_render_pass(
         &self,
         format: ImageFormat,
@@ -33,6 +33,116 @@ impl<B: hal::Backend> RenderPass<B> {
             device.destroy_render_pass(self.r8_depth);
             device.destroy_render_pass(self.bgra8);
             device.destroy_render_pass(self.bgra8_depth);
+        }
+    }
+
+    pub fn create_render_passes(
+        device: &B::Device,
+        surface_format: hal::format::Format,
+        depth_format: hal::format::Format,
+    ) -> HalRenderPasses<B> {
+        let attachment_r8 = hal::pass::Attachment {
+            format: Some(hal::format::Format::R8Unorm),
+            samples: 1,
+            ops: hal::pass::AttachmentOps::new(
+                hal::pass::AttachmentLoadOp::DontCare,
+                hal::pass::AttachmentStoreOp::Store,
+            ),
+            stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
+            layouts: hal::image::Layout::ColorAttachmentOptimal
+                .. hal::image::Layout::ColorAttachmentOptimal,
+        };
+
+        let attachment_bgra8 = hal::pass::Attachment {
+            format: Some(surface_format),
+            samples: 1,
+            ops: hal::pass::AttachmentOps::new(
+                hal::pass::AttachmentLoadOp::DontCare,
+                hal::pass::AttachmentStoreOp::Store,
+            ),
+            stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
+            layouts: hal::image::Layout::ColorAttachmentOptimal
+                .. hal::image::Layout::ColorAttachmentOptimal,
+        };
+
+        let attachment_depth = hal::pass::Attachment {
+            format: Some(depth_format),
+            samples: 1,
+            ops: hal::pass::AttachmentOps::new(
+                hal::pass::AttachmentLoadOp::DontCare,
+                hal::pass::AttachmentStoreOp::Store,
+            ),
+            stencil_ops: hal::pass::AttachmentOps::DONT_CARE,
+            layouts: hal::image::Layout::DepthStencilAttachmentOptimal
+                .. hal::image::Layout::DepthStencilAttachmentOptimal,
+        };
+
+        let subpass_r8 = hal::pass::SubpassDesc {
+            colors: &[(0, hal::image::Layout::ColorAttachmentOptimal)],
+            depth_stencil: None,
+            inputs: &[],
+            resolves: &[],
+            preserves: &[],
+        };
+
+        let subpass_depth_r8 = hal::pass::SubpassDesc {
+            colors: &[(0, hal::image::Layout::ColorAttachmentOptimal)],
+            depth_stencil: Some(&(1, hal::image::Layout::DepthStencilAttachmentOptimal)),
+            inputs: &[],
+            resolves: &[],
+            preserves: &[],
+        };
+
+        let subpass_bgra8 = hal::pass::SubpassDesc {
+            colors: &[(0, hal::image::Layout::ColorAttachmentOptimal)],
+            depth_stencil: None,
+            inputs: &[],
+            resolves: &[],
+            preserves: &[],
+        };
+
+        let subpass_depth_bgra8 = hal::pass::SubpassDesc {
+            colors: &[(0, hal::image::Layout::ColorAttachmentOptimal)],
+            depth_stencil: Some(&(1, hal::image::Layout::DepthStencilAttachmentOptimal)),
+            inputs: &[],
+            resolves: &[],
+            preserves: &[],
+        };
+
+        use std::iter;
+        HalRenderPasses {
+            r8: unsafe {
+                device.create_render_pass(
+                    iter::once(&attachment_r8),
+                    &[subpass_r8],
+                    &[],
+                )
+            }
+            .expect("create_render_pass failed"),
+            r8_depth: unsafe {
+                device.create_render_pass(
+                    iter::once(&attachment_r8).chain(iter::once(&attachment_depth)),
+                    &[subpass_depth_r8],
+                    &[],
+                )
+            }
+            .expect("create_render_pass failed"),
+            bgra8: unsafe {
+                device.create_render_pass(
+                    iter::once(&attachment_bgra8),
+                    &[subpass_bgra8],
+                    &[],
+                )
+            }
+            .expect("create_render_pass failed"),
+            bgra8_depth: unsafe {
+                device.create_render_pass(
+                    &[attachment_bgra8, attachment_depth],
+                    &[subpass_depth_bgra8],
+                    &[],
+                )
+            }
+            .expect("create_render_pass failed"),
         }
     }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3076,6 +3076,8 @@ impl<B: hal::Backend> Renderer<B> {
                 }
                 Some(rect)
             };
+            #[cfg(not(feature = "gleam"))]
+            let clear_rect = None;
 
             self.device.clear_target(clear_color, depth_clear, clear_rect);
 


### PR DESCRIPTION
We have a `begin_render_pass` and `end_render_pass` for each `draw`/`clear_attachments` call, which isn't a performance wise solution. This PR is a first step to change this.

For now we issue a begin and end in `renderer.rs` explicitly in places where it's needed. The next step would be one begin and one end call per WR `RenderPass`.

For this the following needs to be addressed:
 - [ ] Don't break a render pass with `copy\blit_image` calls (These must be executed outside a render pass, but WR logic inserts them inside render passes).
Possible Solution: We could use a shader for this.
- [x] Don't break a render pass if enabling/disabling depth. Changing the depth changes the required Framebuffer attachment for the pass, so we need to start a new one.
Possible Solution: Create new render passes with multiple sub passes for the different cases which can occur during a WR `RenderPass`. This implies changing our current render pass and `Program` creation logic. The question is what is the cost of render pass creation? If it's high we can generate a render pass for the worst scenario (all possible sub passes) during `Device` init and use it for that particular case, with the drawback of having empty sub passes. If it's low we can process a WR `RendePass` and build up a render pass with the required number of sub passes during the run, without empty render passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/312)
<!-- Reviewable:end -->
