### PR TITLE
Make mozangle dependency optional in wrench

### DIFF
--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -43,7 +43,7 @@ default = []
 headless = ["gl", "osmesa-sys", "osmesa-src"]
 pathfinder = ["webrender/pathfinder"]
 gfx = ["dirs"]
-gl = ["gleam", "glutin", "webrender/gleam"]
+gl = ["gleam", "glutin", "mozangle", "webrender/gleam"]
 dx12 = ["gfx-backend-dx12", "gfx", "webrender/push_constants"]
 metal = ["gfx-backend-metal", "gfx", "webrender/push_constants"]
 vulkan = ["gfx-backend-vulkan", "gfx"]
@@ -51,7 +51,7 @@ vulkan = ["gfx-backend-vulkan", "gfx"]
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.8"
 gfx-backend-dx12 = { version = "0.3.4", optional = true, features = ["winit"] }
-mozangle = {version = "0.1.5", features = ["egl"]}
+mozangle = {version = "0.1.5", optional = true, features = ["egl"] }
 
 [target.'cfg(target_os = "macos")'.dependencies.gfx-backend-metal]
 version = "0.3.3"

--- a/wrench/src/egl.rs
+++ b/wrench/src/egl.rs
@@ -3,6 +3,7 @@
 
 //! Based on https://github.com/tomaka/glutin/blob/1b2d62c0e9/src/api/egl/mod.rs
 #![cfg(windows)]
+#![cfg(feature = "gl")]
 #![allow(unused_variables)]
 
 use glutin::ContextError;


### PR DESCRIPTION
We don't need it for gfx-rs backends, and it takes long time to build it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/313)
<!-- Reviewable:end -->
