### PR TITLE
Load rendy-memory configuration from a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ dependencies = [
  "hibitset 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "relevant 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2399,6 +2400,7 @@ dependencies = [
  "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.59.0",
  "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -73,6 +73,7 @@ gfx-backend-empty = "0.3.0"
 gleam = { version = "0.6.2", optional = true}
 glutin = { version = "0.20", optional = true }
 rayon = "1"
+ron = "0.1.7"
 webrender = { path = "../webrender" }
 winit = "0.19"
 

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -219,6 +219,18 @@ pub fn main_wrapper<E: Example>(
 
     println!("Loading shaders...");
     let mut debug_flags = DebugFlags::ECHO_DRIVER_MESSAGES | DebugFlags::TEXTURE_CACHE_DBG;
+
+    #[cfg(feature = "gfx-hal")]
+    let heaps_config = {
+        let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("webrender/res/mem_config.ron");
+        let source = std::fs::read_to_string(&config_path)
+            .expect(&format!("Unable to open memory config file from {:?}", config_path));
+        ron::de::from_str(&source).expect("Unable to parse HeapsConfig")
+    };
+
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,
         precache_flags: E::PRECACHE_SHADER_FLAGS,
@@ -227,16 +239,7 @@ pub fn main_wrapper<E: Example>(
         //scatter_gpu_cache_updates: false,
         debug_flags,
         #[cfg(feature = "gfx-hal")]
-        heaps_config: webrender::HeapsConfig {
-            linear: Some(webrender::LinearConfig {
-                linear_size: 128 * 1024 * 1024,
-            }),
-            dynamic: Some(webrender::DynamicConfig {
-                min_device_allocation: 1024 * 1024,
-                block_size_granularity: 256,
-                max_chunk_size: 32 * 1024 * 1024,
-            })
-        },
+        heaps_config,
         ..options.unwrap_or(webrender::RendererOptions::default())
     };
 

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -47,7 +47,7 @@ plane-split = "0.13.3"
 png = { optional = true, version = "0.14" }
 rand ="0.4"
 rayon = "1"
-rendy-memory = "0.4.0"
+rendy-memory = { version = "0.4.0", features = ["serde"] }
 relevant = { version = "0.4", features = ["std"] }
 ron = "0.1.7"
 rendy-descriptor = "0.4.0"

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -212,6 +212,17 @@ impl Wrench {
             ShaderPrecacheFlags::empty()
         };
 
+        #[cfg(feature = "gfx")]
+        let heaps_config = {
+            let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("webrender/res/mem_config.ron");
+            let source = std::fs::read_to_string(&config_path)
+                .expect(&format!("Unable to open memory config file from {:?}", config_path));
+            ron::de::from_str(&source).expect("Unable to parse HeapsConfig")
+        };
+
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dp_ratio,
             resource_override_path: shader_override_path,
@@ -225,16 +236,7 @@ impl Wrench {
             disable_dual_source_blending,
             chase_primitive,
             #[cfg(feature = "gfx")]
-            heaps_config: webrender::HeapsConfig {
-                linear: Some(webrender::LinearConfig {
-                    linear_size: 128 * 1024 * 1024,
-                }),
-                dynamic: Some(webrender::DynamicConfig {
-                    min_device_allocation: 1024 * 1024,
-                    block_size_granularity: 256,
-                    max_chunk_size: 32 * 1024 * 1024,
-                })
-            },
+            heaps_config,
             ..Default::default()
         };
 


### PR DESCRIPTION
This will help us fine tuning `rendy-memory`'s `HeapsConfig` in Gecko/Servo without always recompile WR with the new limits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/316)
<!-- Reviewable:end -->
