### PR TITLE
Add UpdateWindowSize to scene messages

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -323,6 +323,8 @@ pub enum ResultMsg<B: hal::Backend> {
         BackendProfileCounters,
     ),
     AppendNotificationRequests(Vec<NotificationRequest>),
+    #[cfg(not(feature = "gleam"))]
+    UpdateWindowSize(DeviceIntSize),
 }
 
 #[derive(Clone, Debug)]

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -840,6 +840,8 @@ impl<B: hal::Backend> RenderBackend<B> {
                 doc.view.window_size = window_size;
                 doc.view.inner_rect = inner_rect;
                 doc.view.device_pixel_ratio = device_pixel_ratio;
+                #[cfg(not(feature = "gleam"))]
+                self.result_tx.send(ResultMsg::UpdateWindowSize(window_size)).unwrap();
             }
             SceneMsg::SetDisplayList {
                 epoch,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1847,6 +1847,10 @@ impl<B: hal::Backend> Renderer<B> {
         // Pull any pending results and return the most recent.
         while let Ok(msg) = self.result_rx.try_recv() {
             match msg {
+                #[cfg(not(feature = "gleam"))]
+                ResultMsg::UpdateWindowSize(window_size) => {
+                    self.resize(Some((window_size.width, window_size.height)));
+                }
                 ResultMsg::PublishPipelineInfo(mut pipeline_info) => {
                     for (pipeline_id, epoch) in pipeline_info.epochs {
                         self.pipeline_info.epochs.insert(pipeline_id, epoch);


### PR DESCRIPTION
For some reason it was removed during our resize refactor, but in cases where we resize right after the start (Gecko does this) we will need this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/318)
<!-- Reviewable:end -->
