### PR TITLE
Fix dpi used in wrench

### DIFF
--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -626,7 +626,21 @@ impl<'a> ReftestHarness<'a> {
         self.rx.recv().unwrap();
         let results = self.wrench.render();
 
+        #[cfg(feature = "gl")]
         let window_size = self.window.get_inner_size();
+
+        #[cfg(feature = "gfx")]
+        let window_size = {
+            if let Some(window) = self.window.get_window() {
+                let size = window
+                    .get_inner_size()
+                    .unwrap()
+                    .to_physical(window.get_hidpi_factor());
+                DeviceIntSize::new(size.width as i32, size.height as i32)
+            } else {
+                self.window.get_inner_size()
+            }
+        };
         assert!(
             size.width <= window_size.width &&
             size.height <= window_size.height,


### PR DESCRIPTION
Fixes https://github.com/szeged/webrender/issues/326 by setting the dpi to be always `1.0`,
If we use a different number, we don't pass tests which are using images (png) for the reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/327)
<!-- Reviewable:end -->
