### PR TITLE
Remove Device::reset_program_buffer_offsets

### DIFF
--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -1121,7 +1121,6 @@ impl<B: hal::Backend> Device<B> {
             Self::begin_cmd_buffer(&mut self.command_buffer);
         }
         self.staging_buffer_pool[self.next_id].reset();
-        self.reset_program_buffer_offsets();
         self.instance_buffers[self.next_id].reset(&mut self.free_instance_buffers);
         self.delete_retained_textures();
     }
@@ -1133,15 +1132,6 @@ impl<B: hal::Backend> Device<B> {
         self.bound_read_fbo = DEFAULT_READ_FBO;
         self.bound_draw_fbo = DEFAULT_DRAW_FBO;
         self.draw_target_usage = DrawTargetUsage::Draw;
-    }
-
-    fn reset_program_buffer_offsets(&mut self) {
-        for program in self.programs.values_mut() {
-            if let Some(ref mut index_buffer) = program.index_buffer {
-                index_buffer[self.next_id].reset();
-                program.vertex_buffer.as_mut().unwrap()[self.next_id].reset();
-            }
-        }
     }
 
     pub fn delete_program(&mut self, mut _program: ProgramId) {

--- a/webrender/src/device/gfx/program.rs
+++ b/webrender/src/device/gfx/program.rs
@@ -54,6 +54,7 @@ pub(crate) struct Program<B: hal::Backend> {
     pub(super) shader_name: String,
     pub(super) shader_kind: ShaderKind,
     pub(super) constants: [u32; PUSH_CONSTANT_BLOCK_SIZE / 4],
+    last_frame_used: usize,
 }
 
 impl<B: hal::Backend> Program<B> {
@@ -602,6 +603,7 @@ impl<B: hal::Backend> Program<B> {
             shader_name: String::from(shader_name),
             shader_kind,
             constants: [0; PUSH_CONSTANT_BLOCK_SIZE / 4],
+            last_frame_used: 0,
         }
     }
 
@@ -624,6 +626,13 @@ impl<B: hal::Backend> Program<B> {
         instance_buffer_range: std::ops::Range<usize>,
         format: ImageFormat,
     ) {
+        if self.shader_kind.is_debug() {
+            if self.last_frame_used != next_id {
+                self.vertex_buffer.as_mut().unwrap()[next_id].reset();
+                self.index_buffer.as_mut().unwrap()[next_id].reset();
+                self.last_frame_used = next_id;
+            }
+        }
         let vertex_buffer = match &self.vertex_buffer {
             Some(ref vb) => vb.get(next_id).unwrap(),
             None => vertex_buffer,


### PR DESCRIPTION
`reset_program_buffer_offsets` causes a serious throw-back in performance if the `DebugRenderer` is turned on in Gecko.
Instead of iterating trough the programs we do the reset in the program itself if needed (the program has a debug shader).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/340)
<!-- Reviewable:end -->
