### PR TITLE
Blit with shader to avoid breaking render passes

### DIFF
--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -2465,6 +2465,9 @@ impl<B: hal::Backend> Device<B> {
         filter: TextureFilter,
     ) {
         debug_assert!(self.inside_frame);
+        if self.inside_render_pass {
+            return self.blit_with_shader(src_rect, dest_rect);
+        }
 
         let (src_format, src_img, src_layer) = if self.bound_read_fbo != DEFAULT_READ_FBO {
             let fbo = &self.fbos[&self.bound_read_fbo];
@@ -2475,15 +2478,12 @@ impl<B: hal::Backend> Device<B> {
         };
 
         let (dest_format, dst_img, dest_layer) = if self.bound_draw_fbo != DEFAULT_DRAW_FBO {
-            assert!(!self.inside_render_pass);
             let fbo = &self.fbos[&self.bound_draw_fbo];
             let img = &self.images[&fbo.texture_id];
             let layer = fbo.layer_index;
             (img.format, &img.core, layer)
         } else {
-            info!("Blitting to main target with shader.");
-            self.blit_with_shader(src_rect, dest_rect);
-            return;
+            panic!("Blitting to default draw fbo should be handled by now")
         };
 
         // let src_range = hal::image::SubresourceRange {
@@ -2624,7 +2624,9 @@ impl<B: hal::Backend> Device<B> {
     ) {
         debug_assert!(self.inside_frame);
         self.bind_read_target(src_target);
-        self.bind_draw_target(dest_target, DrawTargetUsage::Draw);
+        if !self.inside_render_pass {
+            self.bind_draw_target(dest_target, DrawTargetUsage::Draw);
+        }
         self.blit_render_target_impl(src_rect, dest_rect, filter);
     }
 
@@ -3258,11 +3260,7 @@ impl<B: hal::Backend> Device<B> {
         depth: Option<f32>,
         rects: impl IntoIterator<Item = FramebufferIntRect>,
     ) {
-        let mut end_pass = false;
-        if !self.inside_render_pass {
-            self.begin_render_pass(false);
-            end_pass = true;
-        }
+        assert!(self.inside_render_pass);
 
         let rects = rects.into_iter().map(|rect| {
             hal::pso::ClearRect {
@@ -3289,9 +3287,6 @@ impl<B: hal::Backend> Device<B> {
         unsafe {
             self.command_buffer
                 .clear_attachments(color_clear.into_iter().chain(depth_clear), rects);
-        }
-        if end_pass {
-            self.end_render_pass();
         }
     }
 

--- a/webrender/src/render_target.rs
+++ b/webrender/src/render_target.rs
@@ -779,6 +779,8 @@ impl TextureCacheRenderTarget {
         && self.border_segments_solid.is_empty()
         && self.line_decorations.is_empty()
         && self.gradients.is_empty()
+        && self.clears.is_empty()
+        && self.blits.is_empty()
     }
 
     pub fn add_task(

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3911,6 +3911,10 @@ impl<B: hal::Backend> Renderer<B> {
                 )
             });
 
+            // Unfortunatelly this clear rect must executed in a separate render pass
+            // because it has a different setup than the subsequent draw calls in draw_alpha_batch_container
+            #[cfg(not(feature = "gl"))]
+            self.device.begin_render_pass(false);
             self.device.clear_target(
                 target.clear_color.map(|c| c.to_array()),
                 Some(1.0),
@@ -3918,6 +3922,8 @@ impl<B: hal::Backend> Renderer<B> {
                 #[cfg(not(feature = "gl"))]
                 false,
             );
+            #[cfg(not(feature = "gl"))]
+            self.device.end_render_pass();
 
             self.device.disable_depth_write();
         }
@@ -4321,9 +4327,11 @@ impl<B: hal::Backend> Renderer<B> {
             self.force_redraw = false;
         }
 
+        #[cfg(not(feature = "gl"))]
+        let mut clear_rects: SmallVec<[FramebufferIntRect; 16]> = SmallVec::new();
+        let clear_color = self.clear_color.map(|color| color.to_array());
         // Clear the framebuffer, if required
         if clear_framebuffer {
-            let clear_color = self.clear_color.map(|color| color.to_array());
 
             match partial_present_mode {
                 Some(PartialPresentMode::Single { dirty_rect }) => {
@@ -4356,17 +4364,10 @@ impl<B: hal::Backend> Renderer<B> {
                     }
                     #[cfg(not(feature = "gl"))]
                     {
-                        let rects = opaque_iter.chain(clear_iter.chain(alpha_iter))
+                        clear_rects = opaque_iter.chain(clear_iter.chain(alpha_iter))
                             .filter(|tile| !tile.dirty_rect.is_empty())
                             .map(|tile| draw_target.to_framebuffer_rect(tile.dirty_rect.to_i32()))
-                            .collect::<SmallVec<[FramebufferIntRect; 16]>>();
-                        if !rects.is_empty() {
-                            self.device.clear_target_rects(
-                                clear_color,
-                                Some(1.0),
-                                rects,
-                            )
-                        }
+                            .collect::<_>();
                     }
                 }
                 None => {
@@ -4383,8 +4384,16 @@ impl<B: hal::Backend> Renderer<B> {
         }
         #[cfg(not(feature = "gl"))]
         {
-            if !composite_state.is_empty() || partial_present_mode.is_none() {
+            let has_clear_attachments = !clear_rects.is_empty();
+            if !composite_state.is_empty() || partial_present_mode.is_none() || has_clear_attachments {
                 self.device.begin_render_pass(transit_to_present);
+                if has_clear_attachments {
+                    self.device.clear_target_rects(
+                        clear_color,
+                        Some(1.0),
+                        clear_rects,
+                    )
+                }
             }
         }
         #[cfg(feature = "gl")]
@@ -4954,6 +4963,11 @@ impl<B: hal::Backend> Renderer<B> {
 
             #[cfg(not(feature = "gl"))]
             {
+                if !target.is_empty() {
+                    self.device.begin_render_pass(false);
+                } else {
+                    self.device.clear_rt_if_needed();
+                }
                 if !target.clears.is_empty() {
                     self.device.clear_target_rects(
                         Some([0.0, 0.0, 0.0, 0.0]),
@@ -4970,16 +4984,6 @@ impl<B: hal::Backend> Renderer<B> {
                 &target.blits, render_tasks, draw_target, &DeviceIntPoint::zero(),
             );
         }
-
-        #[cfg(not(feature = "gl"))]
-        {
-            if !target.is_empty() {
-                self.device.begin_render_pass(false);
-            } else {
-                self.device.clear_rt_if_needed();
-            }
-        }
-
         // Draw any borders for this target.
         if !target.border_segments_solid.is_empty() ||
            !target.border_segments_complex.is_empty()


### PR DESCRIPTION
This depends on https://github.com/szeged/webrender/pull/337.
Also made some minor changes to not call `begin_render_pass` inside `clear_target_rects`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/343)
<!-- Reviewable:end -->
