### PR TITLE
Remove pipeline cache code from swapchain recreation

### DIFF
--- a/webrender/src/device/gfx/device.rs
+++ b/webrender/src/device/gfx/device.rs
@@ -1016,18 +1016,6 @@ impl<B: hal::Backend> Device<B> {
             *layout = hal::image::Layout::Undefined;
         }
 
-        let pipeline_cache = unsafe { self.device.create_pipeline_cache(None) }
-            .expect("Failed to create pipeline cache");
-        if let Some(ref cache) = self.pipeline_cache {
-            unsafe {
-                self.device
-                    .merge_pipeline_caches(&cache, Some(&pipeline_cache))
-                    .expect("merge_pipeline_caches failed");
-                self.device.destroy_pipeline_cache(pipeline_cache);
-            }
-        } else {
-            self.pipeline_cache = Some(pipeline_cache);
-        }
         (
             true,
             DeviceIntSize::new(self.dimensions.0, self.dimensions.1),


### PR DESCRIPTION
This is a follow up for #347. Since we don't have to recreate our programs after resize we don't need a pipeline cache for recreating them. It's sufficient to create the cache in Device::deinit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/szeged/webrender/349)
<!-- Reviewable:end -->
